### PR TITLE
Add label support to preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ Prétraitez les données, entraînez un modèle et évaluez-le :
 
 ```bash
 python scripts/preprocess.py --input_dir data/raw --output_dir data/processed
-python scripts/train.py --data_dir data/processed --model_dir models/
+python scripts/train.py --csv_dir data/processed/csv --model_dir models/
 python scripts/evaluate.py --model_path models/best_model.pth --data_dir data/processed
 ```
+
+Le dossier `data/raw` doit contenir un sous-répertoire par classe (par exemple `data/raw/chat/`, `data/raw/chien/`, ...). Le prétraitement conserve cette structure et génère des spectrogrammes classés dans `data/processed/spectrograms`. Les fichiers CSV produits dans `data/processed/csv` possèdent désormais deux colonnes : `path` et `label`.
 
 Lorsque le script `preprocess.py` isole un cri mais obtient un segment silencieux (volume inférieur à -60 dBFS), le fichier résultant est supprimé et ignoré.

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -22,13 +22,18 @@ SILENCE_THRESH = -40
 
 
 def convert_mp3_to_wav(input_dir: Path, wav_dir: Path) -> None:
-    """Convert all MP3 files in ``input_dir`` to WAV files in ``wav_dir``."""
+    """Recursively convert MP3 files in ``input_dir`` to WAV files in ``wav_dir``.
+
+    The directory structure of ``input_dir`` is mirrored in ``wav_dir`` so that
+    sub-folder names can be used as class labels later on.
+    """
     input_dir = Path(input_dir)
     wav_dir.mkdir(parents=True, exist_ok=True)
 
-    for mp3_path in input_dir.glob("*.mp3"):
+    for mp3_path in input_dir.rglob("*.mp3"):
         audio = AudioSegment.from_mp3(mp3_path)
-        out_path = wav_dir / f"{mp3_path.stem}.wav"
+        relative = mp3_path.relative_to(input_dir).with_suffix(".wav")
+        out_path = wav_dir / relative
         out_path.parent.mkdir(parents=True, exist_ok=True)
         audio.export(out_path, format="wav")
 
@@ -53,6 +58,7 @@ def isolate_cries(audio_path: Path, out_dir: Path) -> list[Path]:
         List of paths to the generated WAV segments.
     """
     audio = AudioSegment.from_file(audio_path)
+    out_dir.mkdir(parents=True, exist_ok=True)
     chunks = silence.split_on_silence(
         audio,
         min_silence_len=500,
@@ -81,29 +87,35 @@ def isolate_cries(audio_path: Path, out_dir: Path) -> list[Path]:
 def generate_spectrograms(wav_dir: Path, spec_dir: Path, sr: int = 22050) -> list[Path]:
     """Generate mel-spectrograms for all WAV files in ``wav_dir``.
 
-    The resulting ``.npy`` files are stored in ``spec_dir`` using the
-    same stem name as the WAV file.
+    The resulting ``.npy`` files are stored in ``spec_dir`` while preserving the
+    directory structure of ``wav_dir``. This allows folder names to be used as
+    class labels.
     """
     wav_dir = Path(wav_dir)
     spec_dir.mkdir(parents=True, exist_ok=True)
 
     spec_paths: list[Path] = []
-    for wav_path in wav_dir.glob("*.wav"):
+    for wav_path in wav_dir.rglob("*.wav"):
         y, _ = librosa.load(wav_path, sr=sr, mono=True)
         mel = librosa.feature.melspectrogram(y=y, sr=sr)
         mel_db = librosa.power_to_db(mel, ref=np.max)
-        out_path = spec_dir / f"{wav_path.stem}.npy"
+        relative = wav_path.relative_to(wav_dir).with_suffix(".npy")
+        out_path = spec_dir / relative
+        out_path.parent.mkdir(parents=True, exist_ok=True)
         np.save(out_path, mel_db)
         spec_paths.append(out_path)
     return spec_paths
 
 
 def split_and_save(files: list[Path], out_dir: Path, train: float = 0.7, val: float = 0.15) -> None:
-    """Split ``files`` into train/val/test sets and save CSV metadata."""
+    """Split ``files`` into train/val/test sets and save CSV metadata including labels."""
     random.shuffle(files)
     n_total = len(files)
     n_train = int(n_total * train)
     n_val = int(n_total * val)
+
+    label_names = sorted({p.parent.name for p in files})
+    label_to_idx = {name: idx for idx, name in enumerate(label_names)}
 
     splits = {
         "train": files[:n_train],
@@ -116,9 +128,9 @@ def split_and_save(files: list[Path], out_dir: Path, train: float = 0.7, val: fl
         csv_path = out_dir / f"{split}.csv"
         with csv_path.open("w", newline="") as f:
             writer = csv.writer(f)
-            writer.writerow(["path"])
+            writer.writerow(["path", "label"])
             for p in split_files:
-                writer.writerow([p.as_posix()])
+                writer.writerow([p.as_posix(), label_to_idx[p.parent.name]])
 
 
 def main() -> None:
@@ -136,8 +148,9 @@ def main() -> None:
 
     processed_paths: list[Path] = []
     processed_dir.mkdir(parents=True, exist_ok=True)
-    for wav_file in wav_dir.glob("*.wav"):
-        processed_paths.extend(isolate_cries(wav_file, processed_dir))
+    for wav_file in wav_dir.rglob("*.wav"):
+        out_dir = processed_dir / wav_file.relative_to(wav_dir).parent
+        processed_paths.extend(isolate_cries(wav_file, out_dir))
 
     spec_paths = generate_spectrograms(processed_dir, spec_dir)
     split_and_save(spec_paths, csv_dir)


### PR DESCRIPTION
## Summary
- generate labels from directory names when preprocessing
- preserve subdirectory structure while converting audio and generating spectrograms
- output `path` and `label` columns in generated CSV files
- document training command and directory structure expectations

## Testing
- `python -m py_compile scripts/preprocess.py`
- `python -m py_compile scripts/train.py`


------
https://chatgpt.com/codex/tasks/task_e_68400673ceac8333bfe90a6d561c3cf8