### PR TITLE
Add requirements file and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ NightScan est un projet de classification de sons d'animaux basé sur des spectr
 - `README.md` — ce fichier
 - `data/` (à créer) — contient les enregistrements (`raw/`) et les spectrogrammes (`processed/`)
 - `models/` (à créer) — répertoire pour stocker les modèles entraînés
-- `scripts/` (à créer) — scripts `preprocess.py`, `train.py` et `evaluate.py` (optionnels et pas encore fournis)
+- `scripts/` — scripts `preprocess.py` et `train.py` pour prétraiter les données et entraîner un modèle. Un script d'évaluation pourra être ajouté ultérieurement.
 - `utils/` (à créer) — fonctions utilitaires
-- `requirements.txt` (à créer) — dépendances Python
+- `requirements.txt` — dépendances Python
 
 ## Installation
 Clonez le dépôt puis installez les dépendances dans un environnement virtuel :
@@ -28,15 +28,14 @@ source env/bin/activate  # Sur Windows : env\Scripts\activate
 pip install -r requirements.txt
 ```
 
-## Utilisation
-Prétraitez les données, entraînez un modèle et évaluez-le :
+Le prétraitement avec `pydub` nécessite également l'outil système **ffmpeg** disponible sur la plupart des distributions Linux et sur Windows.
 
-**Note :** ces scripts peuvent être absents ou inutiles pour le moment.
+## Utilisation
+Prétraitez les données puis entraînez un modèle :
 
 ```bash
 python scripts/preprocess.py --input_dir data/raw --output_dir data/processed
 python scripts/train.py --csv_dir data/processed/csv --model_dir models/
-python scripts/evaluate.py --model_path models/best_model.pth --data_dir data/processed
 ```
 
 Le dossier `data/raw` doit contenir un sous-répertoire par classe (par exemple `data/raw/chat/`, `data/raw/chien/`, ...). Le prétraitement conserve cette structure et génère des spectrogrammes classés dans `data/processed/spectrograms`. Les fichiers CSV produits dans `data/processed/csv` possèdent désormais deux colonnes : `path` et `label`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+librosa
+pydub
+torch
+torchvision


### PR DESCRIPTION
## Summary
- add missing Python dependency list in `requirements.txt`
- clarify project structure in the README
- update installation instructions and usage examples
- mention `ffmpeg` requirement for preprocessing

## Testing
- `python -m py_compile scripts/preprocess.py scripts/train.py`


------
https://chatgpt.com/codex/tasks/task_e_68400e5e50e08333a14b2b09cab750e2