### PR TITLE
Improve prediction preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Lorsque le script `preprocess.py` isole un cri mais obtient un segment silencieu
 ### `predict.py`
 
 - Charge un modèle entraîné et renvoie pour chaque fichier audio les trois classes les plus probables.
+  Le fichier est d'abord découpé en segments de 8 s grâce à la même détection de
+  silence que dans `preprocess.py`. Les segments quasiment silencieux sont
+  ignorés.
 - Exemple d'utilisation :
 
 ```bash


### PR DESCRIPTION
## Summary
- detect silence and split inputs into 8s segments in `predict.py`
- mention the new segmentation step in `README`

## Testing
- `python -m py_compile scripts/predict.py`
- `python -m py_compile scripts/preprocess.py`


------
https://chatgpt.com/codex/tasks/task_e_684030d0e46083338eb88f9f84498dac