### PR TITLE
Add audio dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ source env/bin/activate  # Sur Windows : env\Scripts\activate
 pip install -r requirements.txt
 ```
 
+Avant d'exécuter `preprocess.py`, installez également :
+
+```bash
+brew install portaudio   # macOS uniquement
+pip install pyaudio audioop-lts
+```
+
 Le prétraitement avec `pydub` nécessite également l'outil système **ffmpeg** disponible sur la plupart des distributions Linux et sur Windows.
 Les spectrogrammes sont désormais calculés avec **torchaudio**.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pydub
 torch
 torchvision
 torchaudio
+pyaudio
+audioop-lts


### PR DESCRIPTION
## Summary
- document portaudio, PyAudio and audioop-lts installation in README
- list PyAudio and audioop-lts in requirements

## Testing
- `python -m py_compile scripts/*.py`
- `python -m pip check`

------
https://chatgpt.com/codex/tasks/task_e_68408c92f1b48333acf30f1657e9c24b