### PR TITLE
Fix predict topk bug

### DIFF
--- a/Picture Training/scripts/predict.py
+++ b/Picture Training/scripts/predict.py
@@ -80,12 +80,13 @@ def main() -> None:
     model.eval()
 
     softmax = torch.nn.Softmax(dim=1)
+    top_k = min(3, num_classes)
     with torch.no_grad():
         for batch, paths in loader:
             batch = batch.to(device)
             outputs = model(batch)
             probs = softmax(outputs)
-            values, indices = torch.topk(probs, k=3, dim=1)
+            values, indices = torch.topk(probs, k=top_k, dim=1)
             for path, vals, idxs in zip(paths, values, indices):
                 print(path)
                 for rank, (val, idx) in enumerate(zip(vals, idxs), 1):


### PR DESCRIPTION
## Summary
- fix `predict.py` when dataset has fewer than 3 classes

## Testing
- `python Picture Training/scripts/train.py --csv_dir data/csv --model_dir models --epochs 5 --batch_size 2 --num_workers 0`
- `python Picture Training/scripts/predict.py --model_path models/best_model.pth --csv_dir data/csv data/raw/class_a/a_1.jpg data/raw/class_b/b_0.jpg`

------
https://chatgpt.com/codex/tasks/task_e_684194ebb06c8333840a6697d7d0acb7