### PR TITLE
Validate dataset split ratios

### DIFF
--- a/Audio Training/README.md
+++ b/Audio Training/README.md
@@ -64,7 +64,7 @@ Lorsque le script `preprocess.py` isole un cri mais obtient un segment silencieu
 - Les segments dont le volume moyen est inférieur à `CHUNK_SILENCE_THRESH` (−20 dBFS par défaut) sont ignorés.
 - Les segments valides sont enregistrés dans `output_dir/segments` en conservant la structure de dossiers des classes.
 - Un mél‑spectrogramme est généré pour chaque segment dans `output_dir/spectrograms` à l'aide de **torchaudio**.
-- Les chemins de ces spectrogrammes et leurs étiquettes sont sauvegardés dans `train.csv`, `val.csv` et `test.csv` sous `output_dir/csv` selon un partage 70 % / 15 % / 15 %.
+  - Les chemins de ces spectrogrammes et leurs étiquettes sont sauvegardés dans `train.csv`, `val.csv` et `test.csv` sous `output_dir/csv` selon un partage 70 % / 15 % / 15 % par défaut. Si vous modifiez ces ratios via le code, assurez-vous que chaque valeur est comprise entre 0 et 1 et que la somme de `train` et `val` reste strictement inférieure à 1, faute de quoi une erreur sera levée.
 - Optionnel : `--workers` permet de paralléliser les conversions et traitements.
 
 ### `train.py`

--- a/Audio Training/scripts/preprocess.py
+++ b/Audio Training/scripts/preprocess.py
@@ -183,6 +183,10 @@ def split_and_save(
 ) -> None:
     """Split ``files`` into train/val/test sets and save CSV metadata including labels.
 
+    ``train`` and ``val`` must be in the ``[0, 1]`` range and ``train + val`` must
+    be strictly less than 1, leaving some data for the test split.  A
+    :class:`ValueError` is raised if the ratios are invalid.
+
     Parameters
     ----------
     files:
@@ -192,6 +196,8 @@ def split_and_save(
     seed:
         Optional random seed ensuring deterministic shuffling.
     """
+    if not (0 <= train <= 1) or not (0 <= val <= 1) or train + val >= 1:
+        raise ValueError("Invalid split ratios: train and val must be between 0 and 1, with train + val < 1")
     if seed is not None:
         random.seed(seed)
     random.shuffle(files)

--- a/Picture Training/README.md
+++ b/Picture Training/README.md
@@ -38,14 +38,14 @@ python scripts/prepare_csv.py --input_dir data/raw --output_dir data/csv
 python scripts/train.py --csv_dir data/csv --model_dir models/ --pretrained
 ```
 
-Le dossier `data/raw` doit contenir un sous-dossier par espèce (ex. `data/raw/bubo_bubo/`, `data/raw/capreolus_capreolus/`, ...). Les chemins d'accès aux images sont stockés dans `train.csv`, `val.csv` et `test.csv` selon une répartition 70/15/15.
+Le dossier `data/raw` doit contenir un sous-dossier par espèce (ex. `data/raw/bubo_bubo/`, `data/raw/capreolus_capreolus/`, ...). Les chemins d'accès aux images sont stockés dans `train.csv`, `val.csv` et `test.csv` selon une répartition 70/15/15 par défaut. Si vous changez ces fractions, chaque valeur doit rester comprise entre 0 et 1 et `train + val` doit être strictement inférieur à 1, sinon le programme refusera de générer les CSV.
 
 ### Fonctionnement des scripts
 
 - **`prepare_csv.py`**
   - Scanne tous les dossiers de `--input_dir`.
   - Crée trois fichiers CSV (`train.csv`, `val.csv`, `test.csv`) avec les colonnes `path` et `label`.
-  - Répartition des données configurable (par défaut : 70/15/15).
+  - Répartition des données configurable (par défaut : 70/15/15). Les valeurs fournies doivent être comprises entre 0 et 1 et la somme `train + val` doit rester inférieure à 1.
 
 - **`train.py`**
   - Lit `train.csv` et `val.csv` depuis le dossier indiqué par `--csv_dir`.

--- a/Picture Training/scripts/prepare_csv.py
+++ b/Picture Training/scripts/prepare_csv.py
@@ -18,6 +18,13 @@ def gather_images(input_dir: Path) -> list[Path]:
 
 
 def split_files(files: Sequence[Path], train: float, val: float, *, seed: int | None = None) -> dict[str, list[Path]]:
+    """Split ``files`` into train/val/test subsets.
+
+    ``train`` and ``val`` must be between 0 and 1 and ``train + val`` must be
+    strictly less than 1. A :class:`ValueError` is raised otherwise.
+    """
+    if not (0 <= train <= 1) or not (0 <= val <= 1) or train + val >= 1:
+        raise ValueError("Invalid split ratios: train and val must be between 0 and 1, with train + val < 1")
     if seed is not None:
         random.seed(seed)
     files = list(files)


### PR DESCRIPTION
## Summary
- enforce valid split ratios in audio and picture preprocessing scripts
- document split ratio constraints in READMEs

## Testing
- `python -m py_compile 'Audio Training/scripts/preprocess.py' 'Picture Training/scripts/prepare_csv.py'`

------
https://chatgpt.com/codex/tasks/task_e_68429ce60ab48333817e942720ffb812