### PR TITLE
Lower silence thresholds

### DIFF
--- a/Audio Training/scripts/preprocess.py
+++ b/Audio Training/scripts/preprocess.py
@@ -24,8 +24,8 @@ from pydub.utils import which
 
 
 TARGET_DURATION_MS = 8000  # 8 seconds
-SPLIT_SILENCE_THRESH = -40
-CHUNK_SILENCE_THRESH = -20
+SPLIT_SILENCE_THRESH = -45
+CHUNK_SILENCE_THRESH = -40
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- adjust silence thresholds for segment detection in preprocess script

## Testing
- `python -m py_compile 'Audio Training/scripts/preprocess.py'`


------
https://chatgpt.com/codex/tasks/task_e_6842a9eebcf88333b0e67cab16a302d3