### PR TITLE
Normalize audio when isolating cries

### DIFF
--- a/Audio Training/scripts/preprocess.py
+++ b/Audio Training/scripts/preprocess.py
@@ -86,6 +86,9 @@ def isolate_cries(
     """
     try:
         audio = AudioSegment.from_file(audio_path)
+        # Normalize audio so that the maximum peak is at 0 dBFS
+        if audio.max_dBFS != float("-inf"):
+            audio = audio.apply_gain(-audio.max_dBFS)
     except CouldntDecodeError as exc:
         logger.warning("Could not decode %s: %s", audio_path, exc)
         return []


### PR DESCRIPTION
## Summary
- normalize each audio file at load time in `preprocess.py`

## Testing
- `python -m py_compile 'Audio Training/scripts/preprocess.py'`

------
https://chatgpt.com/codex/tasks/task_e_6842afc9cf608333b178b606b647aa32