### PR TITLE
Add progress to preprocessing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pydub
 torch
 torchaudio
 torchvision
+tqdm


### PR DESCRIPTION
## Summary
- add tqdm requirement
- show progress while copying WAV files
- visualize progress when isolating segments and generating spectrograms
- display progress when writing train/val/test CSV files

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile 'Audio Training/scripts/preprocess.py'`
- `python 'Audio Training/scripts/preprocess.py' --help`

------
https://chatgpt.com/codex/tasks/task_e_6842b36754e88333b29695a9519aa7e0