### PR TITLE
Add tqdm progress bars to training scripts

### DIFF
--- a/Audio Training/scripts/train.py
+++ b/Audio Training/scripts/train.py
@@ -8,6 +8,7 @@ import torch
 from torch.utils.data import Dataset, DataLoader
 from torchvision import models, transforms
 import torch.nn as nn
+from tqdm import tqdm
 
 
 class SpectrogramDataset(Dataset):
@@ -47,7 +48,7 @@ class SpectrogramDataset(Dataset):
 def train_epoch(model: nn.Module, loader: DataLoader, criterion, optimizer, device: torch.device) -> float:
     model.train()
     running_loss = 0.0
-    for inputs, targets in loader:
+    for inputs, targets in tqdm(loader, desc="Training", leave=False):
         inputs, targets = inputs.to(device), targets.to(device)
         optimizer.zero_grad()
         outputs = model(inputs)
@@ -63,7 +64,7 @@ def evaluate(model: nn.Module, loader: DataLoader, criterion, device: torch.devi
     loss = 0.0
     correct = 0
     with torch.no_grad():
-        for inputs, targets in loader:
+        for inputs, targets in tqdm(loader, desc="Validation", leave=False):
             inputs, targets = inputs.to(device), targets.to(device)
             outputs = model(inputs)
             loss += criterion(outputs, targets).item() * inputs.size(0)

--- a/Picture Training/scripts/train.py
+++ b/Picture Training/scripts/train.py
@@ -8,6 +8,7 @@ from torch.utils.data import Dataset, DataLoader
 from torchvision import models, transforms
 from PIL import Image
 import torch.nn as nn
+from tqdm import tqdm
 
 
 class ImageCsvDataset(Dataset):
@@ -38,7 +39,7 @@ class ImageCsvDataset(Dataset):
 def train_epoch(model: nn.Module, loader: DataLoader, criterion, optimizer, device: torch.device) -> float:
     model.train()
     running_loss = 0.0
-    for inputs, targets in loader:
+    for inputs, targets in tqdm(loader, desc="Training", leave=False):
         inputs, targets = inputs.to(device), targets.to(device)
         optimizer.zero_grad()
         outputs = model(inputs)
@@ -54,7 +55,7 @@ def evaluate(model: nn.Module, loader: DataLoader, criterion, device: torch.devi
     loss = 0.0
     correct = 0
     with torch.no_grad():
-        for inputs, targets in loader:
+        for inputs, targets in tqdm(loader, desc="Validation", leave=False):
             inputs, targets = inputs.to(device), targets.to(device)
             outputs = model(inputs)
             loss += criterion(outputs, targets).item() * inputs.size(0)


### PR DESCRIPTION
## Summary
- add tqdm import in both training scripts
- show progress bars during training and validation loops

## Testing
- `python -m py_compile 'Audio Training/scripts/train.py' 'Picture Training/scripts/train.py'`

------
https://chatgpt.com/codex/tasks/task_e_6842d60995f48333bcb766a7b1e5f34e