### PR TITLE
Add REST API for audio predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ python web/app.py
 Update `MODEL_PATH` and `CSV_DIR` in `web/app.py` so they reference a
 trained model and the directory that contains `train.csv`.
 
+The home page exposes a form for manual tests. A POST request to
+`/api/predict` with a WAV file under the `file` field returns the
+predictions as JSON exactly like `predict.py --json`.
+
 ### Example Nginx configuration
 
 ```

--- a/web/app.py
+++ b/web/app.py
@@ -2,7 +2,10 @@ from pathlib import Path
 import subprocess
 import tempfile
 
-from flask import Flask, request, render_template, flash
+import json
+import os
+
+from flask import Flask, request, render_template, flash, jsonify
 
 app = Flask(__name__)
 app.secret_key = "nightscan"
@@ -35,6 +38,35 @@ def index():
                 except subprocess.CalledProcessError as e:
                     result = e.output or str(e)
     return render_template('index.html', result=result)
+
+
+@app.route('/api/predict', methods=['POST'])
+def api_predict():
+    """Return predictions in JSON for an uploaded WAV file."""
+    file = request.files.get('file')
+    if not file or not file.filename.lower().endswith('.wav'):
+        return jsonify({'error': 'Please upload a WAV file.'}), 400
+
+    with tempfile.NamedTemporaryFile(suffix='.wav', delete=False) as tmp:
+        file.save(tmp.name)
+        cmd = [
+            'python', str(PREDICT_SCRIPT),
+            '--model_path', str(MODEL_PATH),
+            '--csv_dir', str(CSV_DIR),
+            '--json',
+            tmp.name,
+        ]
+        try:
+            output = subprocess.check_output(cmd, text=True)
+            data = json.loads(output)
+        except subprocess.CalledProcessError as e:
+            return jsonify({'error': e.output or str(e)}), 500
+        except json.JSONDecodeError:
+            return jsonify({'error': 'Invalid prediction output'}), 500
+        finally:
+            os.unlink(tmp.name)
+
+    return jsonify(data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- expose a new `/api/predict` route returning JSON predictions
- keep the existing HTML form for manual tests
- document the new API in the README

## Testing
- `python -m py_compile web/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684da42ff52c8333a5a325913fe1b42d