### PR TITLE
Add per-user prediction chart shortcode

### DIFF
--- a/wp-plugin/prediction-charts/README.md
+++ b/wp-plugin/prediction-charts/README.md
@@ -1,0 +1,10 @@
+# Prediction Charts WordPress Plugin
+
+This plugin provides a shortcode `[nightscan_chart]` that displays a stacked bar chart of predictions per hour and species. Data is read from the `ns_predictions` table and filtered so that logged‑in users see only their own results.
+
+Usage:
+1. Upload the `prediction-charts` folder to your `wp-content/plugins/` directory.
+2. Activate the plugin in WordPress.
+3. Insert the shortcode on any page: `[nightscan_chart]`.
+
+The chart is built with Chart.js loaded from a CDN.

--- a/wp-plugin/prediction-charts/prediction-charts.php
+++ b/wp-plugin/prediction-charts/prediction-charts.php
@@ -1,0 +1,70 @@
+<?php
+/*
+Plugin Name: Prediction Charts
+Description: Display prediction counts per hour and species using Chart.js.
+Version: 1.0
+*/
+
+if (!defined('ABSPATH')) exit;
+
+function pc_enqueue_scripts() {
+    wp_enqueue_script('chartjs', 'https://cdn.jsdelivr.net/npm/chart.js', array(), null, true);
+}
+add_action('wp_enqueue_scripts', 'pc_enqueue_scripts');
+
+function pc_get_data() {
+    global $wpdb, $current_user;
+    wp_get_current_user();
+    $table = $wpdb->prefix . 'ns_predictions';
+    $rows = $wpdb->get_results($wpdb->prepare(
+        "SELECT species, DATE_FORMAT(predicted_at, '%Y-%m-%d %H:00:00') as hour, COUNT(*) as cnt FROM $table WHERE user_id = %d GROUP BY species,hour ORDER BY hour", $current_user->ID), ARRAY_A);
+
+    $data = array();
+    foreach ($rows as $r) {
+        $hour = $r['hour'];
+        if (!isset($data[$hour])) $data[$hour] = array();
+        $data[$hour][$r['species']] = intval($r['cnt']);
+    }
+    return $data;
+}
+
+function pc_render_chart() {
+    if (!is_user_logged_in()) return '<p>You must be logged in to view this chart.</p>';
+    $data = pc_get_data();
+    $hours = array_keys($data);
+    sort($hours);
+    $species = array();
+    foreach ($data as $h => $vals) {
+        foreach ($vals as $sp => $count) {
+            if (!in_array($sp, $species)) $species[] = $sp;
+        }
+    }
+    sort($species);
+    $dataset_js = '';
+    foreach ($species as $sp) {
+        $counts = array();
+        foreach ($hours as $h) {
+            $counts[] = isset($data[$h][$sp]) ? $data[$h][$sp] : 0;
+        }
+        $color = sprintf('#%06X', mt_rand(0, 0xFFFFFF));
+        $dataset_js .= json_encode(array('label'=>$sp,'data'=>$counts,'backgroundColor'=>$color)) . ',';
+    }
+    $dataset_js = rtrim($dataset_js, ',');
+    ob_start();
+    ?>
+    <canvas id="pc-chart" width="400" height="200"></canvas>
+    <script>
+    const ctx = document.getElementById('pc-chart').getContext('2d');
+    new Chart(ctx, {
+        type: 'bar',
+        data: {
+            labels: <?php echo json_encode($hours); ?>,
+            datasets: [<?php echo $dataset_js; ?>]
+        },
+        options: { scales: { x: { stacked: true }, y: { stacked: true } } }
+    });
+    </script>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode('nightscan_chart', 'pc_render_chart');


### PR DESCRIPTION
## Summary
- implement a new `prediction-charts` WordPress plugin
- show counts per hour and species in a stacked bar chart with Chart.js
- filter the data so logged‑in users only see their own predictions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684da72c08408333a128dddcc3fd5314