### PR TITLE
Load Flask secret key from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ python web/app.py
 ```
 
 Set the `PREDICT_API_URL` environment variable to point to your
-prediction service. The home page exposes a form for manual tests.
+prediction service. You must also define `SECRET_KEY` to configure the
+Flask session signing; use a random string for production.
+The home page exposes a form for manual tests.
 When a WAV file is submitted, the server posts it to this API and
 displays the JSON response.
 

--- a/web/app.py
+++ b/web/app.py
@@ -22,7 +22,10 @@ from flask_login import (
 from werkzeug.security import generate_password_hash, check_password_hash
 
 app = Flask(__name__)
-app.secret_key = "nightscan"
+secret_key = os.environ.get("SECRET_KEY")
+if not secret_key:
+    raise RuntimeError("SECRET_KEY environment variable not set")
+app.secret_key = secret_key
 app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///site.db"
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 


### PR DESCRIPTION
## Summary
- read `SECRET_KEY` from environment in `web/app.py`
- document the environment variable in the README

## Testing
- `python -m py_compile web/app.py`
- `SECRET_KEY=testsecret python web/app.py & sleep 3; pkill -f web/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684dde72f23c83338356842311c73fdb