### PR TITLE
Add Flask usage doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ source env/bin/activate
 python web/app.py
 ```
 
+The application creates a local SQLite database on first run and stores
+predictions for each authenticated user. See
+[`docs/flask_app.md`](docs/flask_app.md) for details on the login routes,
+database initialization and how to switch to another backend such as MySQL.
+
 Set the `PREDICT_API_URL` environment variable to point to your
 prediction service. You must also define `SECRET_KEY` to configure the
 Flask session signing; use a random string for production.

--- a/docs/flask_app.md
+++ b/docs/flask_app.md
@@ -1,0 +1,48 @@
+# Application Flask
+
+Ce document décrit brièvement le fonctionnement de l'application Web située dans le dossier `web/`.
+
+## Création de la base SQLite
+
+Lors du démarrage de l'application (`python web/app.py`), Flask crée une base SQLite locale si elle n'existe pas déjà. Cela se fait par l'appel suivant :
+
+```python
+with app.app_context():
+    db.create_all()
+```
+
+La base `site.db` est stockée dans le même dossier que l'application. Les tables `user` et `prediction` sont générées à partir des modèles définis dans `app.py`.
+
+## Routes de connexion et d'inscription
+
+Deux pages permettent d'enregistrer un nouvel utilisateur ou de se connecter :
+
+- `GET /register` et `POST /register` : formulaire d'inscription. Un nom d'utilisateur et un mot de passe sont demandés. Une fois la création réussie, l'utilisateur est invité à se connecter.
+- `GET /login` et `POST /login` : formulaire de connexion. Après authentification, l'utilisateur est redirigé vers l'index.
+- `GET /logout` : déconnexion de la session en cours.
+
+L'accès à la page principale (`/`) est protégé par `@login_required` : seul un utilisateur connecté peut envoyer des fichiers et consulter son historique de prédictions.
+
+## Association des prédictions à l'utilisateur
+
+Chaque résultat est enregistré dans la table `prediction` avec la colonne `user_id`. Lorsqu'un utilisateur connecté soumet un fichier :
+
+```python
+pred = Prediction(
+    user_id=current_user.id,
+    filename=file.filename,
+    result=json.dumps(result),
+)
+```
+
+Ainsi, l'historique affiché sur la page d'accueil correspond uniquement aux prédictions de l'utilisateur actif.
+
+## Utiliser une autre base de données
+
+SQLite convient pour les tests ou un usage local. Pour passer sur MySQL (ou tout autre SGBD pris en charge par SQLAlchemy), modifiez la variable de configuration `SQLALCHEMY_DATABASE_URI` dans `web/app.py` :
+
+```python
+app.config["SQLALCHEMY_DATABASE_URI"] = "mysql+pymysql://nom:motdepasse@hote/basededonnees"
+```
+
+Installez ensuite le connecteur nécessaire (par exemple `pip install pymysql`) et exécutez à nouveau `db.create_all()` dans le contexte de l'application pour créer les tables sur cette nouvelle base.


### PR DESCRIPTION
## Summary
- add instructions for using the Flask web interface
- mention the new docs in the README

## Testing
- `python -m py_compile web/app.py`


------
https://chatgpt.com/codex/tasks/task_e_684e996f876c8333890fcb90256368d5