### PR TITLE
Add documentation for WordPress plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,11 @@ The script prints the three most probable classes for each audio
 segment. Add `--json` to get the result as JSON. No environment
 variables are required for this command, but the dependencies installed
 in `env/` (PyTorch, torchaudio, pydub, etc.) must be available.
+
+## WordPress plugin
+
+A small plugin located in `wp-plugin/prediction-charts` can display
+user prediction statistics inside WordPress. See
+[`docs/wordpress_plugin.md`](docs/wordpress_plugin.md) for the expected
+database structure, how to export data from the Flask app and an example
+of the `[nightscan_chart]` shortcode.

--- a/docs/wordpress_plugin.md
+++ b/docs/wordpress_plugin.md
@@ -1,0 +1,57 @@
+# Plugin WordPress "Prediction Charts"
+
+Ce document décrit la structure de la table `ns_predictions` utilisée par le plugin
+`prediction-charts` ainsi que la synchronisation possible des données
+entre la base Flask et la base WordPress.
+
+## Structure de la table `ns_predictions`
+
+Le plugin s'attend à trouver une table dans la base de données WordPress
+(portant le préfixe habituel, par exemple `wp_ns_predictions`) contenant au
+minimum les colonnes suivantes :
+
+| Colonne      | Type        | Description                                    |
+| ------------ | ----------- | ---------------------------------------------- |
+| `id`         | INT AUTO_INCREMENT | Clef primaire. |
+| `user_id`    | INT NOT NULL | Identifiant de l'utilisateur WordPress. |
+| `species`    | VARCHAR(100) NOT NULL | Nom de l'espèce prédite. |
+| `predicted_at` | DATETIME NOT NULL | Date et heure de la prédiction. |
+
+D'autres champs (score de confiance, nom du fichier, etc.) peuvent être
+ajoutés selon vos besoins mais ne sont pas utilisés par le shortcode.
+
+## Export des prédictions depuis Flask
+
+L'application Flask stocke les résultats dans la table `prediction` de la
+base `site.db` (SQLite par défaut). Pour alimenter WordPress il suffit de
+copier ces enregistrements dans `ns_predictions`. Un petit script Python peut
+faire le relais :
+
+```python
+import sqlite3
+import MySQLdb  # ou pymysql
+
+sqlite_conn = sqlite3.connect('web/site.db')
+mysql = MySQLdb.connect(host='localhost', user='wpuser', passwd='secret', db='wordpress')
+
+for row in sqlite_conn.execute('SELECT user_id, json_extract(result, "$.best") AS species, id FROM prediction'):
+    with mysql.cursor() as cur:
+        cur.execute(
+            "INSERT INTO wp_ns_predictions (user_id, species, predicted_at) VALUES (%s, %s, NOW())",
+            (row[0], row[1])
+        )
+    mysql.commit()
+```
+
+Adaptez les paramètres de connexion et les champs selon votre schéma exact.
+L'opération peut être programmée via `cron` pour une synchronisation régulière.
+
+## Installation du plugin
+
+1. Copiez le dossier `prediction-charts` dans `wp-content/plugins/`.
+2. Activez **Prediction Charts** depuis l'administration WordPress.
+3. Insérez le shortcode `[nightscan_chart]` dans une page ou un article.
+
+Une fois activé, chaque utilisateur connecté verra un graphique représentant
+le nombre de prédictions par heure et par espèce sur les données qui lui
+sont associées.


### PR DESCRIPTION
## Summary
- document the `prediction-charts` WordPress plugin
- explain the expected `ns_predictions` table and data export
- mention the plugin in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e9aec39a08333a05b7cf483272bb8