### PR TITLE
Update silence threshold documentation

### DIFF
--- a/Audio_Training/README.md
+++ b/Audio_Training/README.md
@@ -62,8 +62,8 @@ Lorsque le script `preprocess.py` isole un cri mais obtient un segment silencieu
 -### `preprocess.py`
 
 - Copie les fichiers WAV dans `output_dir/wav` en conservant la structure des dossiers.
-- Découpe chaque WAV en segments de 8 secondes grâce à la détection de silence (`SPLIT_SILENCE_THRESH` à −40 dBFS par défaut). Les segments trop courts sont complétés par du silence et ceux trop longs sont tronqués.
-- Les segments dont le volume moyen est inférieur à `CHUNK_SILENCE_THRESH` (−20 dBFS par défaut) sont ignorés.
+- Découpe chaque WAV en segments de 8 secondes grâce à la détection de silence (`SPLIT_SILENCE_THRESH` à −35 dBFS par défaut). Les segments trop courts sont complétés par du silence et ceux trop longs sont tronqués.
+- Les segments dont le volume moyen est inférieur à `CHUNK_SILENCE_THRESH` (−35 dBFS par défaut) sont ignorés.
 - Les segments valides sont enregistrés dans `output_dir/segments` en conservant la structure de dossiers des classes.
 - Un mél‑spectrogramme est généré pour chaque segment dans `output_dir/spectrograms` à l'aide de **torchaudio**.
   - Les chemins de ces spectrogrammes et leurs étiquettes sont sauvegardés dans `train.csv`, `val.csv` et `test.csv` sous `output_dir/csv` selon un partage 70 % / 15 % / 15 % par défaut. Si vous modifiez ces ratios via le code, assurez-vous que chaque valeur est comprise entre 0 et 1 et que la somme de `train` et `val` reste strictement inférieure à 1, faute de quoi une erreur sera levée.


### PR DESCRIPTION
## Summary
- correct `SPLIT_SILENCE_THRESH` and `CHUNK_SILENCE_THRESH` defaults in `Audio_Training/README.md`

## Testing
- `grep -n 'CHUNK_SILENCE_THRESH' Audio_Training/README.md`


------
https://chatgpt.com/codex/tasks/task_e_684eb97dc9988333a725bee011022611