### PR TITLE
Update repo URL references

### DIFF
--- a/Audio_Training/README.md
+++ b/Audio_Training/README.md
@@ -22,7 +22,8 @@ NightScan est un projet de classification de sons d'animaux basé sur des spectr
 Clonez le dépôt puis installez les dépendances dans un environnement virtuel :
 
 ```bash
-git clone https://github.com/votre-utilisateur/NightScan.git
+git clone https://github.com/GamerXtrem/NightScan.git
+# Remplacez "GamerXtrem" par votre nom d'utilisateur si vous utilisez votre propre fork
 cd NightScan
 python -m venv env
 source env/bin/activate  # Sur Windows : env\Scripts\activate

--- a/Manuel.txt
+++ b/Manuel.txt
@@ -20,7 +20,8 @@ Linux : souvent disponible dans les dépôts (sudo apt install ffmpeg sur Ubuntu
 Créer un dossier pour le projet
 Ouvrir un terminal ou un invite de commandes et saisir :
 
-git clone https://github.com/votre-utilisateur/NightScan.git
+git clone https://github.com/GamerXtrem/NightScan.git
+# Remplacez "GamerXtrem" par votre nom d'utilisateur si vous utilisez votre propre fork
 cd NightScan
 Installer les dépendances du projet
 Toujours dans le terminal, exécuter :

--- a/Picture_Training/README.md
+++ b/Picture_Training/README.md
@@ -22,7 +22,8 @@ NightScan est un projet de classification d'animaux à partir de photos. Les ima
 Clonez le dépôt puis installez les dépendances dans un environnement virtuel :
 
 ```bash
-git clone https://github.com/votre-utilisateur/NightScan.git
+git clone https://github.com/GamerXtrem/NightScan.git
+# Remplacez "GamerXtrem" par votre nom d'utilisateur si vous utilisez votre propre fork
 cd NightScan
 python -m venv env
 source env/bin/activate  # Sur Windows : env\Scripts\activate

--- a/setup_vps_infomaniak.sh
+++ b/setup_vps_infomaniak.sh
@@ -10,8 +10,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
 # Clone the repository if it is not already present
+# Replace "GamerXtrem" with your GitHub username if using your own fork
+REPO_URL="https://github.com/GamerXtrem/NightScan.git"
 if [ ! -d .git ]; then
-    git clone https://github.com/votre-utilisateur/NightScan.git NightScan
+    git clone "$REPO_URL" NightScan
     cd NightScan
 fi
 


### PR DESCRIPTION
## Summary
- update documentation to point to the official repo
- replace placeholder URL in VPS setup script

## Testing
- `python -m compileall -q Audio_Training Picture_Training web wp-plugin`

------
https://chatgpt.com/codex/tasks/task_e_684ebd6d6f8c833395a24e4d2f1aa536