### PR TITLE
Add English translations of docs

### DIFF
--- a/Audio_Training/README_en.md
+++ b/Audio_Training/README_en.md
@@ -1,0 +1,89 @@
+# NightScan
+
+## Overview
+NightScan is a project for classifying animal sounds using spectrograms generated from audio recordings. The pipeline converts raw audio files into 8‑second spectrograms, trains deep learning models and evaluates performance.
+
+## Key features
+- Preprocess audio files into uniform‑length spectrograms.
+- Train classification models with PyTorch.
+- Evaluate models on validation sets.
+- Save the best trained model.
+
+## Project layout
+- `README.md` — this file
+- `data/` — holds recordings (`raw/`) and spectrograms (`processed/`)
+- `models/` — directory for storing trained models
+- `scripts/` — `preprocess.py`, `train.py` and `predict.py` for preprocessing, training and prediction
+- `utils/` — utility functions
+- `setup.sh` — script that automatically creates the `data/`, `models/` and `utils/` folders
+- `../requirements.txt` — common Python dependencies (root level)
+
+## Installation
+Clone the repository and install dependencies in a virtual environment:
+
+```bash
+git clone https://github.com/GamerXtrem/NightScan.git
+# Replace "GamerXtrem" with your own username if using your fork
+cd NightScan
+python -m venv env
+source env/bin/activate  # On Windows: env\Scripts\activate
+pip install -r requirements.txt
+cd Audio_Training
+chmod +x setup.sh
+./setup.sh
+```
+
+The `setup.sh` script, run from `Audio_Training`, creates the required `data/`, `models/` and `utils/` folders.
+
+Before running `preprocess.py`, also install:
+
+```bash
+brew install portaudio   # macOS only
+pip install pyaudio audioop-lts
+```
+
+Preprocessing with `pydub` also requires **ffmpeg** on the system. Check that the `ffmpeg` command is available (`ffmpeg -version` in a terminal). Spectrograms are now computed using **torchaudio**.
+
+## Usage
+Preprocess the data and train a model:
+
+```bash
+python scripts/preprocess.py --input_dir data/raw --output_dir data/processed --workers 4
+python scripts/train.py --csv_dir data/processed/csv --model_dir models/ --pretrained
+```
+
+The `data/raw` folder must contain one subdirectory per class (e.g. `data/raw/cat/`, `data/raw/dog/`, ...). Preprocessing keeps this structure and generates spectrograms in `data/processed/spectrograms`. The CSV files in `data/processed/csv` now have two columns: `path` and `label`.
+
+When `preprocess.py` isolates a cry but gets a silent segment (volume below `CHUNK_SILENCE_THRESH`), the resulting file is deleted and ignored.
+
+## How the scripts work
+
+### `preprocess.py`
+- Copies WAV files to `output_dir/wav` while preserving folder structure.
+- Splits each WAV into 8‑second segments using silence detection (`SPLIT_SILENCE_THRESH` −35 dBFS by default). Short segments are padded with silence and long ones are truncated.
+- Segments whose average volume is below `CHUNK_SILENCE_THRESH` (−35 dBFS) are skipped.
+- Valid segments are saved under `output_dir/segments` keeping class folders.
+- A mel spectrogram is generated for each segment under `output_dir/spectrograms` with **torchaudio**.
+  - Paths and labels of these spectrograms are stored in `train.csv`, `val.csv` and `test.csv` inside `output_dir/csv` with a default 70/15/15 split. If you change these ratios in the code, make sure each value is between 0 and 1 and that `train + val` remains strictly below 1, otherwise an error is raised.
+- Optional: `--workers` allows parallel conversions and processing.
+
+### `train.py`
+- Reads `train.csv` and `val.csv` from the directory given by `--csv_dir`.
+- Loads each `.npy` spectrogram, normalizes it to 0‑1, resizes to 224×224 and duplicates it on three channels to use with ResNet18.
+- Trains a ResNet18 on GPU or MPS (Apple Silicon) if available. ImageNet weights can be loaded with `--pretrained`.
+- After each epoch, displays the loss and validation accuracy and saves to `--model_dir/best_model.pth` the model achieving the best accuracy.
+- Optional parameters: `--epochs` (default 10), `--batch_size` (32), `--lr` (1e-3) and `--num_workers` (0).
+
+### `predict.py`
+- Loads a trained model and returns the three most probable classes for each audio file. The file is first split into 8‑s segments using the same silence detection as in `preprocess.py`. Almost silent segments are skipped.
+- Example usage:
+
+```bash
+python scripts/predict.py --model_path models/best_model.pth --csv_dir data/processed/csv sample.wav
+```
+
+- To get JSON output:
+
+```bash
+python scripts/predict.py --model_path models/best_model.pth --csv_dir data/processed/csv --json sample.wav
+```

--- a/Manual_en.md
+++ b/Manual_en.md
@@ -1,0 +1,80 @@
+# NightScan User Guide
+
+NightScan classifies animal calls from audio files. This simplified manual explains how to use the project without developer knowledge.
+
+## 1. Prepare your environment
+Install Python (version 3.10 or newer)
+
+- **Windows**: download Python from python.org and install it.
+- **macOS and Linux**: Python is usually already installed. Check with `python --version` in a terminal.
+
+Install **FFMPEG**, required for converting audio files.
+
+- **Windows**: download "ffmpeg" from ffmpeg.org and follow the instructions.
+- **macOS**: you can install it via Homebrew: `brew install ffmpeg`.
+- **Linux**: often available in repositories (e.g. `sudo apt install ffmpeg` on Ubuntu).
+
+Create a folder for the project and run:
+
+```bash
+git clone https://github.com/GamerXtrem/NightScan.git
+# Replace "GamerXtrem" with your own username if using your fork
+cd NightScan
+```
+
+Install the project dependencies:
+
+```bash
+python -m venv env          # create an isolated environment
+source env/bin/activate     # on Windows: env\Scripts\activate
+pip install -r requirements.txt
+```
+
+## 2. Prepare the audio data
+Organize your recordings:
+
+Create a `data/raw` directory with one subfolder per animal type,
+e.g. `data/raw/cat/`, `data/raw/dog/`, etc. Place your WAV files in the appropriate subfolders.
+
+Launch preprocessing:
+
+```bash
+python Audio_Training/scripts/preprocess.py --input_dir data/raw --output_dir data/processed --workers 4
+```
+
+This program:
+
+- Copies the WAV files into the output folder.
+- Splits sounds into 8‑second segments.
+- Creates spectrograms (images representing the sounds).
+- Generates three CSV files (`train.csv`, `val.csv`, `test.csv`) describing the data.
+
+You end up with a new `data/processed` folder containing the split WAVs, spectrograms and CSVs.
+
+## 3. Train the model
+Run training:
+
+```bash
+python Audio_Training/scripts/train.py --csv_dir data/processed/csv --model_dir models --pretrained
+```
+
+The program reads the CSVs, loads the spectrograms and trains the model. Training may take several minutes (or more depending on your hardware). The best model is saved as `models/best_model.pth`.
+
+## 4. Identify sounds
+Prepare one or more audio files (e.g. `mysound.wav`) in an accessible folder.
+
+Launch prediction:
+
+```bash
+python Audio_Training/scripts/predict.py --model_path models/best_model.pth --csv_dir data/processed/csv mysound.wav
+```
+
+The script splits the audio, runs the model and prints the three most probable species (e.g., cat, dog, etc.) with their scores. Use `--json` to get JSON output.
+
+## 5. Tips and troubleshooting
+- **No sound detected?** Ensure your recording contains cries or sounds loud enough. Very quiet segments are skipped.
+- **FFMPEG error message?** Check that FFMPEG is installed and in your PATH (`ffmpeg -version` in a terminal).
+- **Using multiple cores**: the `--workers 4` option speeds up preprocessing on multi‑core machines. Adjust as needed.
+- **Model backups**: trained models are stored in the `models` folder. Keep them to avoid retraining each time.
+
+In summary, NightScan converts your recordings into audio images, trains a model to recognize your animals, and lets you identify the contents of new sound files. Only basic command line knowledge is required to follow these steps.

--- a/Picture_Training/README_en.md
+++ b/Picture_Training/README_en.md
@@ -1,0 +1,67 @@
+# NightScan - Image Classification
+
+## Overview
+NightScan is a project for classifying animals from photos. Images are listed in CSV files and used to train a ResNet18 model with PyTorch.
+
+## Key features
+- Structured loading of images organized by folder.
+- Unified normalization and resizing of images.
+- Train a CNN model (ResNet18) with the `--pretrained` option.
+- Evaluate on a validation set and save the best model.
+
+## Project layout
+- `README.md` — this file
+- `data/` — raw images (`raw/`) and CSVs (`csv/`)
+- `models/` — directory for trained models
+- `scripts/` — `prepare_csv.py`, `train.py` and `predict.py`
+- `utils/` — utility functions
+- `Picture_Training/setup.sh` — script to create required folders
+- `../requirements.txt` — common Python dependencies (root level)
+
+## Installation
+Clone the repository and install dependencies in a virtual environment:
+
+```bash
+git clone https://github.com/GamerXtrem/NightScan.git
+# Replace "GamerXtrem" with your own username if using your fork
+cd NightScan
+python -m venv env
+source env/bin/activate  # On Windows: env\Scripts\activate
+pip install -r requirements.txt
+chmod +x Picture_Training/setup.sh
+./Picture_Training/setup.sh
+```
+
+## Usage
+Prepare the CSV files from images and start training:
+
+```bash
+python scripts/prepare_csv.py --input_dir data/raw --output_dir data/csv
+python scripts/train.py --csv_dir data/csv --model_dir models/ --pretrained
+```
+
+The `data/raw` folder must contain a subdirectory per species (e.g. `data/raw/bubo_bubo/`, `data/raw/capreolus_capreolus/`, ...). Image paths are stored in `train.csv`, `val.csv` and `test.csv` with a default 70/15/15 split. If you change these fractions, each value must be between 0 and 1 and `train + val` must be strictly less than 1 or the program will refuse to generate the CSVs.
+
+### How the scripts work
+
+- **`prepare_csv.py`**
+  - Scans all folders in `--input_dir`.
+  - Creates `train.csv`, `val.csv` and `test.csv` with columns `path` and `label`.
+  - Configurable data split (default: 70/15/15). The values provided must be between 0 and 1 and `train + val` must remain below 1.
+
+- **`train.py`**
+  - Reads `train.csv` and `val.csv` from the folder specified by `--csv_dir`.
+  - Loads images, resizes them to 224×224 and normalizes them according to ImageNet.
+  - Trains a ResNet18 (optionally pre-trained).
+  - Automatically saves the best model in `--model_dir/best_model.pth`.
+  - Parameters: `--epochs`, `--batch_size`, `--lr`, `--num_workers`.
+
+- **`predict.py`**
+  - Loads a trained model and predicts the species of one or more images.
+  - Applies the same transformations as during training.
+  - Displays the top 3 predicted classes with their confidence score.
+  - Requires the `--csv_dir` argument to load class names from `train.csv`.
+
+```bash
+python scripts/predict.py --model_path models/best_model.pth --csv_dir data/csv image.jpg
+```

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ The project is organized into two main folders:
 - **Audio_Training/** – tools for preparing audio clips, generating spectrograms and training models to classify animal sounds.
 - **Picture_Training/** – scripts for building image datasets and training image recognition models.
 
-For a quick overview of how to set up and run the audio workflow, see **Manuel.txt** at the repository root.
+For a quick overview of how to set up and run the audio workflow, see **Manuel.txt** (French) or **Manual_en.md** at the repository root.
 
-**Documentation language notice**: `Manuel.txt` and the files under `docs/` are written in French. Official English translations are not yet available, so you may wish to use online translation tools if you prefer to read the instructions in another language.
+**Documentation language notice**: French originals are provided along with English translations in `docs/en/` and `Manual_en.md`.
 
 ## VPS setup
 

--- a/docs/en/flask_app.md
+++ b/docs/en/flask_app.md
@@ -1,0 +1,63 @@
+# Flask Application
+
+This document briefly explains how the web app in the `web/` folder works.
+
+## Creating the SQLite database
+
+When the app starts (`python web/app.py`), Flask creates a local SQLite database if it does not already exist:
+
+```python
+with app.app_context():
+    db.create_all()
+```
+
+The `site.db` file lives in the same folder as the application. The `user` and `prediction` tables are generated from the models defined in `app.py`.
+
+## Login and registration routes
+
+Two pages let you create an account or log in:
+
+- `GET /register` and `POST /register`: registration form asking for a user name and password. After successful creation, the user is prompted to log in.
+- `GET /login` and `POST /login`: login form. After authentication the user is redirected to the index page.
+- `GET /logout`: logs out the current session.
+
+Access to the main page (`/`) is protected by `@login_required`: only logged‑in users can upload files and view their prediction history.
+
+## Associating predictions with the user
+
+Each result is stored in the `prediction` table with a `user_id` column. When an authenticated user submits a file:
+
+```python
+pred = Prediction(
+    user_id=current_user.id,
+    filename=file.filename,
+    result=json.dumps(result),
+)
+```
+
+The history displayed on the home page therefore only shows the predictions of the active user.
+
+## Using another database
+
+SQLite is suitable for testing or local use. To switch to MySQL (or any other SQLAlchemy‑supported backend), change the `SQLALCHEMY_DATABASE_URI` configuration in `web/app.py`:
+
+```python
+app.config["SQLALCHEMY_DATABASE_URI"] = "mysql+pymysql://user:password@host/dbname"
+```
+
+Install the required connector (for example `pip install pymysql`) and run `db.create_all()` again within the application context to create the tables on the new database.
+
+## Environment variables
+
+Before starting the Flask server, define two variables:
+
+- `SECRET_KEY`: used to sign the session. Choose a random value in production.
+- `PREDICT_API_URL`: URL of the API that receives the files to analyze. If not set, `web/app.py` defaults to `http://localhost:8000/api/predict`.
+
+Example:
+
+```bash
+export SECRET_KEY="change-me"
+export PREDICT_API_URL="http://myserver/api/predict"
+python web/app.py
+```

--- a/docs/en/vps_lite_first_connection.md
+++ b/docs/en/vps_lite_first_connection.md
@@ -1,0 +1,77 @@
+# First SSH Connection to an Infomaniak VPS Cloud / VPS Lite
+
+This guide summarizes the steps to connect to an Infomaniak server for the first time.
+
+## Open a root session
+
+In your local terminal or a tool like *PuTTY* (Windows), run:
+
+```bash
+sudo -i
+```
+
+This command opens an interactive session with **root** privileges.
+
+## Connection from macOS or Linux
+
+Use the command:
+
+```bash
+ssh -i <path/to/private_key> <user>@<ip_address>
+```
+
+- `<path/to/private_key>`: path to your private key (permissions `0700` recommended).
+- `<user>`: default user name depending on the distribution (see table below).
+- `<ip_address>`: server IPv4 address shown in the Manager.
+
+Example:
+
+```bash
+ssh -i c:/path/key ubuntu@192.168.1.1
+```
+
+If you see `WARNING: UNPROTECTED PRIVATE KEY FILE!`, fix the permissions:
+
+```bash
+chmod 400 <path/to/private_key>
+```
+
+## Connection from Windows
+
+Windows does not include a full SSH client by default. Two options:
+
+1. Enable the *Bash shell* (Windows 10 or later).
+2. Use the free **PuTTY** and **PuTTYgen** utilities.
+
+### Converting the private key
+
+- Open **PuTTYgen** and click **Load** to import your private key.
+- Then save it with **Save private key**.
+
+### PuTTY settings
+
+- Under **Session**:
+  - **HostName**: server IPv4 address.
+  - **Port**: leave `22` (default).
+  - **Connection type**: choose **SSH**.
+- Under **Connection / SSH / Auth**:
+  - Select the private key generated with PuTTYgen using **Browse**.
+- Click **Open** to launch the terminal and enter your user name.
+
+## Default users
+
+| Linux distribution | User |
+| ------------------ | ----- |
+| AlmaLinux | `almalinux` |
+| Arch Linux | `arch` |
+| CentOS | `cloud-user` |
+| Debian ≤ 7 | `root` |
+| Debian ≥ 8 | `debian` |
+| Fedora | `fedora` |
+| FreeBSD | `freebsd` |
+| Ubuntu | `ubuntu` |
+| OpenBSD | `openbsd` |
+| openSUSE Leap 15 | `opensuse` |
+| openSUSE 42 | `root` |
+| RancherOS | `rancher` |
+| SUSE Linux Enterprise Server | `root` |

--- a/docs/en/wordpress_plugin.md
+++ b/docs/en/wordpress_plugin.md
@@ -1,0 +1,48 @@
+# "Prediction Charts" WordPress Plugin
+
+This document describes the `ns_predictions` table used by the `prediction-charts` plugin and how to sync data between the Flask database and WordPress.
+
+## Structure of the `ns_predictions` table
+
+The plugin expects a table in the WordPress database (with the usual prefix, e.g. `wp_ns_predictions`) containing at least the following columns:
+
+| Column      | Type        | Description                         |
+| ----------- | ----------- | ----------------------------------- |
+| `id`        | INT AUTO_INCREMENT | Primary key. |
+| `user_id`   | INT NOT NULL | WordPress user ID. |
+| `species`   | VARCHAR(100) NOT NULL | Name of the predicted species. |
+| `predicted_at` | DATETIME NOT NULL | Date and time of the prediction. |
+
+You may add other fields (confidence score, file name, etc.) as needed, but they are not used by the shortcode.
+
+## Exporting predictions from Flask
+
+The Flask application stores results in the `prediction` table of the `site.db` (SQLite by default). Each entry has a `result` field in JSON format. Its `predictions` array contains the best species in the first element. To populate WordPress, simply copy these records into `ns_predictions`. A small Python script can act as a bridge:
+
+```python
+import sqlite3
+import MySQLdb  # or pymysql
+
+sqlite_conn = sqlite3.connect('web/site.db')
+mysql = MySQLdb.connect(host='localhost', user='wpuser', passwd='secret', db='wordpress')
+
+for row in sqlite_conn.execute(
+    "SELECT user_id, json_extract(result, '$.predictions[0].label') AS species, id FROM prediction"
+):
+    with mysql.cursor() as cur:
+        cur.execute(
+            "INSERT INTO wp_ns_predictions (user_id, species, predicted_at) VALUES (%s, %s, NOW())",
+            (row[0], row[1])
+        )
+    mysql.commit()
+```
+
+Adjust the connection parameters and fields to match your exact schema. You can run this via `cron` for regular synchronization.
+
+## Plugin installation
+
+1. Copy the `prediction-charts` folder into `wp-content/plugins/`.
+2. Activate **Prediction Charts** from the WordPress admin.
+3. Insert the `[nightscan_chart]` shortcode into a page or post.
+
+Once activated, each logged‑in user will see a chart showing the number of predictions per hour and species for their own data.


### PR DESCRIPTION
## Summary
- provide new English documentation under `docs/en/`
- translate `Manuel.txt` to `Manual_en.md`
- add English READMEs for audio and picture training
- update root README with note about available translations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ec2a26fe083339722c6f6ea97e204