### PR TITLE
Add API server and docs

### DIFF
--- a/Audio_Training/scripts/api_server.py
+++ b/Audio_Training/scripts/api_server.py
@@ -1,0 +1,90 @@
+import argparse
+import tempfile
+from pathlib import Path
+from typing import List, Dict
+
+from flask import Flask, request, jsonify
+import torch
+from torch.utils.data import DataLoader
+from torchvision import models
+
+import predict
+
+app = Flask(__name__)
+
+model: torch.nn.Module
+labels: List[str]
+device: torch.device
+
+
+def load_model(model_path: Path, csv_dir: Path) -> None:
+    global model, labels, device
+    labels = predict.load_labels(csv_dir)
+    num_classes = len(labels)
+    model = models.resnet18()
+    model.fc = torch.nn.Linear(model.fc.in_features, num_classes)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    state = torch.load(model_path, map_location=device)
+    model.load_state_dict(state)
+    model.to(device)
+    model.eval()
+
+
+def predict_file(path: Path) -> List[Dict]:
+    dataset = predict.AudioDataset([path])
+    loader = DataLoader(dataset, batch_size=1, shuffle=False)
+    softmax = torch.nn.Softmax(dim=1)
+    results: List[Dict] = []
+    with torch.no_grad():
+        for batch, paths in loader:
+            batch = batch.to(device)
+            outputs = model(batch)
+            probs = softmax(outputs)
+            values, indices = torch.topk(probs, k=3, dim=1)
+            for p, vals, idxs in zip(paths, values, indices):
+                seg_idx = 0
+                if "#" in p:
+                    try:
+                        seg_idx = int(p.rsplit("#", 1)[1])
+                    except ValueError:
+                        seg_idx = 0
+                results.append(
+                    {
+                        "segment": p,
+                        "time": seg_idx * (predict.TARGET_DURATION_MS / 1000),
+                        "predictions": [
+                            {"label": labels[idx.item()], "probability": float(val)}
+                            for val, idx in zip(vals, idxs)
+                        ],
+                    }
+                )
+    return results
+
+
+@app.post("/api/predict")
+def api_predict():
+    file = request.files.get("file")
+    if not file or not file.filename:
+        return jsonify({"error": "No file uploaded"}), 400
+    if not file.filename.lower().endswith(".wav"):
+        return jsonify({"error": "WAV file required"}), 400
+    with tempfile.NamedTemporaryFile(suffix=".wav") as tmp:
+        file.save(tmp.name)
+        tmp.flush()
+        results = predict_file(Path(tmp.name))
+    return jsonify(results)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Start prediction API server")
+    parser.add_argument("--model_path", type=Path, required=True, help="Path to trained model")
+    parser.add_argument("--csv_dir", type=Path, required=True, help="Directory containing train.csv")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8000)
+    args = parser.parse_args()
+    load_model(args.model_path, args.csv_dir)
+    app.run(host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ database initialization and how to switch to another backend such as MySQL.
 Set the `PREDICT_API_URL` environment variable to point to your
 prediction service. You must also define `SECRET_KEY` to configure the
 Flask session signing; use a random string for production.
+To start a local API using the trained model, run:
+
+```bash
+python Audio_Training/scripts/api_server.py \
+  --model_path models/best_model.pth \
+  --csv_dir data/processed/csv
+```
+
+`web/app.py` expects this API to listen on `http://localhost:8000/api/predict`
+unless you override `PREDICT_API_URL`.
 The home page exposes a form for manual tests.
 When a WAV file is submitted, the server posts it to this API and
 displays the JSON response.

--- a/docs/api_server.md
+++ b/docs/api_server.md
@@ -1,0 +1,15 @@
+# API de prédiction
+
+Ce module fournit un petit serveur Flask exposant l'endpoint `POST /api/predict`. Il accepte un fichier WAV et renvoie les prédictions au format JSON comme celles affichées par `predict.py --json`.
+
+## Lancer le serveur
+
+Activez l'environnement virtuel puis lancez :
+
+```bash
+python Audio_Training/scripts/api_server.py \
+  --model_path models/best_model.pth \
+  --csv_dir data/processed/csv
+```
+
+Par défaut, l'API écoute sur `0.0.0.0:8000`. Les options `--host` et `--port` permettent de changer cette adresse.

--- a/docs/flask_app.md
+++ b/docs/flask_app.md
@@ -64,3 +64,15 @@ export SECRET_KEY="change-me"
 export PREDICT_API_URL="http://monserveur/api/predict"
 python web/app.py
 ```
+
+Avant de lancer l'application Web, assurez-vous que l'API de prédiction est
+active. Elle se démarre avec :
+
+```bash
+python Audio_Training/scripts/api_server.py \
+  --model_path models/best_model.pth \
+  --csv_dir data/processed/csv
+```
+
+Par défaut, l'API écoute sur `0.0.0.0:8000`, ce qui correspond à l'URL utilisée
+par `web/app.py`.


### PR DESCRIPTION
## Summary
- add a Flask API server to run predictions
- document how to launch the new server in README and docs
- mention API startup in the web app documentation

## Testing
- `python -m py_compile Audio_Training/scripts/api_server.py`

------
https://chatgpt.com/codex/tasks/task_e_684ec4a971208333b8ff94b12f4b7579