### PR TITLE
Fix API server import path and default port

### DIFF
--- a/Audio_Training/scripts/api_server.py
+++ b/Audio_Training/scripts/api_server.py
@@ -1,12 +1,16 @@
 import argparse
 import tempfile
+import sys
 from pathlib import Path
 from typing import List, Dict
+import pathlib
 
 from flask import Flask, request, jsonify
 import torch
 from torch.utils.data import DataLoader
 from torchvision import models
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent))
 
 import predict
 
@@ -80,7 +84,7 @@ def main() -> None:
     parser.add_argument("--model_path", type=Path, required=True, help="Path to trained model")
     parser.add_argument("--csv_dir", type=Path, required=True, help="Directory containing train.csv")
     parser.add_argument("--host", default="0.0.0.0")
-    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--port", type=int, default=8001)
     args = parser.parse_args()
     load_model(args.model_path, args.csv_dir)
     app.run(host=args.host, port=args.port)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ python Audio_Training/scripts/api_server.py \
   --csv_dir data/processed/csv
 ```
 
-`web/app.py` expects this API to listen on `http://localhost:8000/api/predict`
+`web/app.py` expects this API to listen on `http://localhost:8001/api/predict`
 unless you override `PREDICT_API_URL`.
 The home page exposes a form for manual tests.
 When a WAV file is submitted, the server posts it to this API and

--- a/docs/api_server.md
+++ b/docs/api_server.md
@@ -12,4 +12,5 @@ python Audio_Training/scripts/api_server.py \
   --csv_dir data/processed/csv
 ```
 
-Par défaut, l'API écoute sur `0.0.0.0:8000`. Les options `--host` et `--port` permettent de changer cette adresse.
+Par défaut, l'API écoute sur `0.0.0.0:8001`. Les options `--host` et `--port` permettent de changer cette adresse.
+Assurez-vous de ne pas utiliser le même port que l'application Flask afin d'éviter les collisions.

--- a/docs/en/flask_app.md
+++ b/docs/en/flask_app.md
@@ -52,12 +52,12 @@ Install the required connector (for example `pip install pymysql`) and run `db.c
 Before starting the Flask server, define two variables:
 
 - `SECRET_KEY`: used to sign the session. Choose a random value in production.
-- `PREDICT_API_URL`: URL of the API that receives the files to analyze. If not set, `web/app.py` defaults to `http://localhost:8000/api/predict`.
+- `PREDICT_API_URL`: URL of the API that receives the files to analyze. If not set, `web/app.py` defaults to `http://localhost:8001/api/predict`.
 
 Example:
 
 ```bash
 export SECRET_KEY="change-me"
-export PREDICT_API_URL="http://myserver/api/predict"
+export PREDICT_API_URL="http://myserver:8001/api/predict"
 python web/app.py
 ```

--- a/docs/flask_app.md
+++ b/docs/flask_app.md
@@ -55,13 +55,13 @@ Avant de démarrer le serveur Flask, deux variables doivent être définies :
   aléatoire pour un déploiement réel.
 - `PREDICT_API_URL` : URL de l'API recevant les fichiers à analyser. Sans
   configuration explicite, `web/app.py` se rabat sur
-  `http://localhost:8000/api/predict`.
+  `http://localhost:8001/api/predict`.
 
 Exemple :
 
 ```bash
 export SECRET_KEY="change-me"
-export PREDICT_API_URL="http://monserveur/api/predict"
+export PREDICT_API_URL="http://monserveur:8001/api/predict"
 python web/app.py
 ```
 
@@ -74,5 +74,6 @@ python Audio_Training/scripts/api_server.py \
   --csv_dir data/processed/csv
 ```
 
-Par défaut, l'API écoute sur `0.0.0.0:8000`, ce qui correspond à l'URL utilisée
-par `web/app.py`.
+Par défaut, l'API écoute sur `0.0.0.0:8001`. Vérifiez que `PREDICT_API_URL`
+utilise bien ce port ou ajustez-le si nécessaire pour éviter toute collision
+avec l'application Flask.

--- a/web/app.py
+++ b/web/app.py
@@ -33,7 +33,7 @@ db = SQLAlchemy(app)
 login_manager = LoginManager(app)
 login_manager.login_view = "login"
 
-PREDICT_API_URL = os.environ.get("PREDICT_API_URL", "http://localhost:8000/api/predict")
+PREDICT_API_URL = os.environ.get("PREDICT_API_URL", "http://localhost:8001/api/predict")
 
 
 class User(db.Model, UserMixin):


### PR DESCRIPTION
## Summary
- fix `import predict` in API server by extending `sys.path`
- change API server default port to `8001`
- update web app default `PREDICT_API_URL`
- document new port and clarify startup instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ecd0acf808333b14080a64699d1bf