### PR TITLE
Fix plugin scheme and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ python Audio_Training/scripts/api_server.py \
 
 `web/app.py` expects this API to listen on `http://localhost:8001/api/predict`
 unless you override `PREDICT_API_URL`.
+You can point `PREDICT_API_URL` to either an `http://` or `https://` endpoint
+depending on your deployment; the application works with both.
 The home page exposes a form for manual tests.
 When a WAV file is submitted, the server posts it to this API and
 displays the JSON response.

--- a/docs/en/flask_app.md
+++ b/docs/en/flask_app.md
@@ -52,7 +52,7 @@ Install the required connector (for example `pip install pymysql`) and run `db.c
 Before starting the Flask server, define two variables:
 
 - `SECRET_KEY`: used to sign the session. Choose a random value in production.
-- `PREDICT_API_URL`: URL of the API that receives the files to analyze. If not set, `web/app.py` defaults to `http://localhost:8001/api/predict`.
+- `PREDICT_API_URL`: URL of the API that receives the files to analyze. If not set, `web/app.py` defaults to `http://localhost:8001/api/predict`. This variable may use either `http://` or `https://` depending on your API's configuration.
 
 Example:
 

--- a/docs/flask_app.md
+++ b/docs/flask_app.md
@@ -55,7 +55,8 @@ Avant de démarrer le serveur Flask, deux variables doivent être définies :
   aléatoire pour un déploiement réel.
 - `PREDICT_API_URL` : URL de l'API recevant les fichiers à analyser. Sans
   configuration explicite, `web/app.py` se rabat sur
-  `http://localhost:8001/api/predict`.
+  `http://localhost:8001/api/predict`. Cette variable peut pointer vers un
+  endpoint en `http://` ou `https://` selon votre configuration.
 
 Exemple :
 

--- a/wp-plugin/prediction-charts/README.md
+++ b/wp-plugin/prediction-charts/README.md
@@ -7,4 +7,4 @@ Usage:
 2. Activate the plugin in WordPress.
 3. Insert the shortcode on any page: `[nightscan_chart]`.
 
-The chart is built with Chart.js loaded from a CDN.
+The chart is built with Chart.js loaded from a CDN. The script URL is scheme-relative (`//cdn.jsdelivr.net/npm/chart.js`) so the plugin works whether your site uses HTTP or HTTPS.

--- a/wp-plugin/prediction-charts/prediction-charts.php
+++ b/wp-plugin/prediction-charts/prediction-charts.php
@@ -8,7 +8,8 @@ Version: 1.0
 if (!defined('ABSPATH')) exit;
 
 function pc_enqueue_scripts() {
-    wp_enqueue_script('chartjs', 'https://cdn.jsdelivr.net/npm/chart.js', array(), null, true);
+    // Load Chart.js with a scheme-relative URL so the plugin works on HTTP and HTTPS
+    wp_enqueue_script('chartjs', '//cdn.jsdelivr.net/npm/chart.js', array(), null, true);
 }
 add_action('wp_enqueue_scripts', 'pc_enqueue_scripts');
 


### PR DESCRIPTION
## Summary
- load Chart.js via scheme-relative URL
- clarify plugin and docs support HTTP or HTTPS endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2beede648333b2ed1c679df9a51b