### PR TITLE
Add audio upload shortcode plugin

### DIFF
--- a/wp-plugin/audio-upload/audio-upload.php
+++ b/wp-plugin/audio-upload/audio-upload.php
@@ -1,0 +1,46 @@
+<?php
+/*
+Plugin Name: NightScan Audio Upload
+Description: Provides a shortcode allowing users to upload WAV files that are forwarded to a configurable API endpoint.
+Version: 1.0
+*/
+
+if (!defined('ABSPATH')) exit;
+
+function nsau_render_form() {
+    $output = '';
+    if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_FILES['ns_audio_file'])) {
+        if (!isset($_POST['nsau_nonce']) || !wp_verify_nonce($_POST['nsau_nonce'], 'nsau_upload')) {
+            $output .= '<p>Nonce verification failed.</p>';
+        } else {
+            $file = $_FILES['ns_audio_file'];
+            if ($file['error'] !== UPLOAD_ERR_OK) {
+                $output .= '<p>File upload error.</p>';
+            } else {
+                $endpoint = get_option('ns_api_endpoint');
+                if (!$endpoint) {
+                    $output .= '<p>API endpoint not configured.</p>';
+                } else {
+                    $body = file_get_contents($file['tmp_name']);
+                    $response = wp_remote_post($endpoint, array(
+                        'headers' => array('Content-Type' => 'audio/wav'),
+                        'body'    => $body,
+                    ));
+                    if (is_wp_error($response)) {
+                        $output .= '<p>Request error: '.esc_html($response->get_error_message()).'</p>';
+                    } else {
+                        $json = wp_remote_retrieve_body($response);
+                        $output .= '<pre>'.esc_html($json).'</pre>';
+                    }
+                }
+            }
+        }
+    }
+    $output .= '<form method="post" enctype="multipart/form-data">';
+    $output .= '<input type="file" name="ns_audio_file" accept=".wav" required>';
+    $output .= wp_nonce_field('nsau_upload', 'nsau_nonce', true, false);
+    $output .= '<input type="submit" value="Upload">';
+    $output .= '</form>';
+    return $output;
+}
+add_shortcode('nightscan_uploader', 'nsau_render_form');


### PR DESCRIPTION
## Summary
- add new `NightScan Audio Upload` WordPress plugin
- implement `[nightscan_uploader]` shortcode to send WAV files to the configured API endpoint

## Testing
- `python -m py_compile Picture_Training/scripts/predict.py`
- `python -m py_compile Picture_Training/scripts/train.py Audio_Training/scripts/preprocess.py Audio_Training/scripts/api_server.py Audio_Training/scripts/predict.py Audio_Training/scripts/train.py web/app.py`
- `php -l wp-plugin/audio-upload/audio-upload.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b29bdce083338e309eceea21d99d