### PR TITLE
Add documentation for WordPress upload plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,19 @@ user prediction statistics inside WordPress. See
 [`docs/wordpress_plugin.md`](docs/wordpress_plugin.md) for the expected
 database structure, how to export data from the Flask app and an example
 of the `[nightscan_chart]` shortcode.
+
+## Uploading from WordPress
+
+The repository also includes **NightScan Audio Upload**, a plugin that
+lets WordPress send WAV files directly to your prediction API. Copy the
+`wp-plugin/audio-upload` folder into `wp-content/plugins/` and activate
+it from the admin panel. Set the API endpoint with the `ns_api_endpoint`
+option so the plugin knows where to post the files, e.g. using WP‑CLI:
+
+```bash
+wp option update ns_api_endpoint https://your-vps.example/api/predict
+```
+
+Your WordPress site can run on a different host from the prediction
+server. Just make sure the API endpoint is reachable (enable CORS and
+HTTPS if needed) so uploads succeed.

--- a/docs/en/flask_app.md
+++ b/docs/en/flask_app.md
@@ -23,6 +23,11 @@ Two pages let you create an account or log in:
 
 Access to the main page (`/`) is protected by `@login_required`: only logged‑in users can upload files and view their prediction history.
 
+For public deployments you may instead send files from a WordPress site using
+the upload plugin described in `docs/en/wordpress_plugin.md`. The built‑in form
+is mainly for testing and can be omitted when uploads happen through
+WordPress.
+
 ## Associating predictions with the user
 
 Each result is stored in the `prediction` table with a `user_id` column. When an authenticated user submits a file:

--- a/docs/en/wordpress_plugin.md
+++ b/docs/en/wordpress_plugin.md
@@ -46,3 +46,19 @@ Adjust the connection parameters and fields to match your exact schema. You can 
 3. Insert the `[nightscan_chart]` shortcode into a page or post.
 
 Once activated, each logged‑in user will see a chart showing the number of predictions per hour and species for their own data.
+
+## Audio upload plugin
+
+The repository also ships with **NightScan Audio Upload**. Copy the
+`audio-upload` folder to `wp-content/plugins/` and activate it. Place the
+`[nightscan_uploader]` shortcode in a page to show the upload form. The
+plugin reads the API URL from the `ns_api_endpoint` option, which you can
+set for example with:
+
+```bash
+wp option update ns_api_endpoint https://your-vps.example/api/predict
+```
+
+The API may reside on a different server than WordPress. If so, ensure
+that CORS is allowed and use HTTPS when required so the browser is able to
+post the files successfully.

--- a/docs/flask_app.md
+++ b/docs/flask_app.md
@@ -23,6 +23,11 @@ Deux pages permettent d'enregistrer un nouvel utilisateur ou de se connecter :
 
 L'accès à la page principale (`/`) est protégé par `@login_required` : seul un utilisateur connecté peut envoyer des fichiers et consulter son historique de prédictions.
 
+Pour un déploiement public, vous pouvez aussi transmettre les fichiers depuis
+un site WordPress grâce au plugin d'envoi décrit dans
+`docs/wordpress_plugin.md`. Le formulaire local reste utile pour les tests mais
+n'est pas obligatoire si l'envoi se fait depuis WordPress.
+
 ## Association des prédictions à l'utilisateur
 
 Chaque résultat est enregistré dans la table `prediction` avec la colonne `user_id`. Lorsqu'un utilisateur connecté soumet un fichier :

--- a/docs/wordpress_plugin.md
+++ b/docs/wordpress_plugin.md
@@ -59,3 +59,20 @@ L'opération peut être programmée via `cron` pour une synchronisation réguli�
 Une fois activé, chaque utilisateur connecté verra un graphique représentant
 le nombre de prédictions par heure et par espèce sur les données qui lui
 sont associées.
+
+## Plugin d'envoi de fichiers
+
+Le dépôt contient également un plugin **NightScan Audio Upload** permettant de
+transférer des fichiers WAV vers l'API depuis WordPress. Copiez le dossier
+`audio-upload` dans `wp-content/plugins/` puis activez-le. Placez le
+shortcode `[nightscan_uploader]` dans une page pour afficher le formulaire
+d'envoi. Le plugin lit l'option `ns_api_endpoint` pour connaître l'URL de
+l'API, à configurer par exemple avec :
+
+```bash
+wp option update ns_api_endpoint https://mon-vps.exemple/api/predict
+```
+
+L'API peut être hébergée sur un autre serveur que WordPress. Vérifiez dans ce
+cas que le domaine accepte les requêtes CORS et utilisez HTTPS si nécessaire
+afin que l'envoi fonctionne correctement.


### PR DESCRIPTION
## Summary
- document how to upload from WordPress
- explain audio upload plugin and shortcode usage
- clarify cross-host requirements
- mention WordPress uploads in Flask docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b3fce5e0833386f24ee5b6d65737