### PR TITLE
Explain CORS setup for WordPress uploads

### DIFF
--- a/Audio_Training/scripts/api_server.py
+++ b/Audio_Training/scripts/api_server.py
@@ -1,3 +1,16 @@
+"""Minimal Flask API serving model predictions.
+
+If you need to call this endpoint from another domain (for example the
+WordPress uploader plugin), enable Cross‑Origin Resource Sharing. Install
+``flask_cors`` then initialize it like so::
+
+    from flask_cors import CORS
+    CORS(app, origins=["https://your-wordpress.example"])
+
+Replace the URL with your own site so the response includes the correct
+``Access-Control-Allow-Origin`` header.
+"""
+
 import argparse
 import tempfile
 import sys

--- a/README.md
+++ b/README.md
@@ -129,5 +129,6 @@ wp option update ns_api_endpoint https://your-vps.example/api/predict
 ```
 
 Your WordPress site can run on a different host from the prediction
-server. Just make sure the API endpoint is reachable (enable CORS and
-HTTPS if needed) so uploads succeed.
+server. Enable CORS in `Audio_Training/scripts/api_server.py` so your
+WordPress domain is allowed (see `docs/api_server.md`). HTTPS is also
+recommended so uploads succeed.

--- a/docs/api_server.md
+++ b/docs/api_server.md
@@ -14,3 +14,18 @@ python Audio_Training/scripts/api_server.py \
 
 Par défaut, l'API écoute sur `0.0.0.0:8001`. Les options `--host` et `--port` permettent de changer cette adresse.
 Assurez-vous de ne pas utiliser le même port que l'application Flask afin d'éviter les collisions.
+
+## Autoriser le domaine WordPress
+
+Si l'API est appelée depuis un site tiers, le navigateur refusera la requête
+sans en-tête CORS. Installez `flask_cors` puis ajoutez dans
+`Audio_Training/scripts/api_server.py` :
+
+```python
+from flask_cors import CORS
+CORS(app, origins=["https://mon-site-wordpress.exemple"])
+```
+
+Remplacez l'URL par celle de votre WordPress. L'entête
+`Access-Control-Allow-Origin` contiendra ce domaine et l'envoi de fichiers
+depuis le plugin fonctionnera.


### PR DESCRIPTION
## Summary
- document how to activate CORS directly in `api_server.py`
- add a section in `docs/api_server.md` about allowing the WordPress domain
- mention enabling CORS in the README so remote uploads work

## Testing
- `python -m py_compile Audio_Training/scripts/api_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6851b5d8c5e083338aa96ae9a2bba1ee