### PR TITLE
Add English API docs and update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ The project is organized into two main folders:
 - **Audio_Training/** – tools for preparing audio clips, generating spectrograms and training models to classify animal sounds.
 - **Picture_Training/** – scripts for building image datasets and training image recognition models.
 
-For a quick overview of how to set up and run the audio workflow, see **Manuel.txt** (French) or **Manual_en.md** at the repository root.
-
-**Documentation language notice**: French originals are provided along with English translations in `docs/en/` and `Manual_en.md`.
+For a quick overview of how to set up and run the audio workflow, see **Manual_en.md** at the repository root.
 
 ## VPS setup
 
@@ -24,7 +22,7 @@ The script clones the repository if needed, installs `git`, `python3`,
 requirements (including `pyaudio`).
 
 If you are deploying on a new Infomaniak VPS, see
-[`docs/vps_lite_first_connection.md`](docs/vps_lite_first_connection.md)
+[`docs/en/vps_lite_first_connection.md`](docs/en/vps_lite_first_connection.md)
 for instructions on making the initial SSH connection.
 
 ## Web interface
@@ -42,7 +40,7 @@ python web/app.py
 
 The application creates a local SQLite database on first run and stores
 predictions for each authenticated user. See
-[`docs/flask_app.md`](docs/flask_app.md) for details on the login routes,
+[`docs/en/flask_app.md`](docs/en/flask_app.md) for details on the login routes,
 database initialization and how to switch to another backend such as MySQL.
 
 Set the `PREDICT_API_URL` environment variable to point to your
@@ -112,7 +110,7 @@ in `env/` (PyTorch, torchaudio, pydub, etc.) must be available.
 
 A small plugin located in `wp-plugin/prediction-charts` can display
 user prediction statistics inside WordPress. See
-[`docs/wordpress_plugin.md`](docs/wordpress_plugin.md) for the expected
+[`docs/en/wordpress_plugin.md`](docs/en/wordpress_plugin.md) for the expected
 database structure, how to export data from the Flask app and an example
 of the `[nightscan_chart]` shortcode.
 
@@ -130,5 +128,5 @@ wp option update ns_api_endpoint https://your-vps.example/api/predict
 
 Your WordPress site can run on a different host from the prediction
 server. Enable CORS in `Audio_Training/scripts/api_server.py` so your
-WordPress domain is allowed (see `docs/api_server.md`). HTTPS is also
+WordPress domain is allowed (see `docs/en/api_server.md`). HTTPS is also
 recommended so uploads succeed.

--- a/docs/en/api_server.md
+++ b/docs/en/api_server.md
@@ -1,0 +1,26 @@
+# Prediction API
+
+This module provides a small Flask server exposing the `POST /api/predict` endpoint. It accepts a WAV file and returns predictions in JSON format like those printed by `predict.py --json`.
+
+## Launch the server
+
+Activate the virtual environment then run:
+
+```bash
+python Audio_Training/scripts/api_server.py \
+  --model_path models/best_model.pth \
+  --csv_dir data/processed/csv
+```
+
+By default the API listens on `0.0.0.0:8001`. The `--host` and `--port` options let you change this address. Make sure not to reuse the Flask app's port to avoid conflicts.
+
+## Allow the WordPress domain
+
+If the API is called from a third-party site, the browser will reject the request without CORS headers. Install `flask_cors` then add the following in `Audio_Training/scripts/api_server.py`:
+
+```python
+from flask_cors import CORS
+CORS(app, origins=["https://my-wordpress.example"])
+```
+
+Replace the URL with that of your WordPress site. The `Access-Control-Allow-Origin` header will contain this domain so file uploads from the plugin work correctly.


### PR DESCRIPTION
## Summary
- add `docs/en/api_server.md` translated from French original
- update documentation links to use the English versions
- remove French manual references from README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6851bd9ab2ec8333a9e723547de4d2d1