### PR TITLE
Add upload size limits and store file_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ depending on your deployment; the application works with both.
 The home page exposes a form for manual tests.
 When a WAV file is submitted, the server posts it to this API and
 displays the JSON response.
+Uploads larger than 100 MB are rejected and each user may store up to
+10 GB of audio in the database.
 
 ### Example Nginx configuration
 

--- a/docs/en/flask_app.md
+++ b/docs/en/flask_app.md
@@ -37,8 +37,13 @@ pred = Prediction(
     user_id=current_user.id,
     filename=file.filename,
     result=json.dumps(result),
+    file_size=file_size,
 )
 ```
+
+`file_size` stores the uploaded file's size in bytes. The application rejects
+files larger than 100 MB and prevents each user from uploading more than
+10 GB in total.
 
 The history displayed on the home page therefore only shows the predictions of the active user.
 


### PR DESCRIPTION
## Summary
- add upload size limit constants in `app.py`
- store file size in `Prediction` model
- validate upload size and user's total storage
- document the new `file_size` column and limits
- mention quota in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685315a634808333af46f4e45a1e71d9