### PR TITLE
Add upload size notice to index

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -10,6 +10,7 @@
   <p>Logged in as {{ current_user.username }} | <a href="{{ url_for('logout') }}">Logout</a></p>
   <form action="/" method="post" enctype="multipart/form-data">
     <input type="file" name="file" accept="audio/wav" required>
+    <p>Maximum 100 MB per file, 10 GB total for your account. WAV files only.</p>
     <input type="submit" value="Analyze">
   </form>
   {% else %}


### PR DESCRIPTION
## Summary
- add a note about account upload limits on the main page

## Testing
- `python -m py_compile web/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6853173dde1c8333b4608d3a41760c7a