### PR TITLE
Add file size check to api server

### DIFF
--- a/docs/en/api_server.md
+++ b/docs/en/api_server.md
@@ -24,3 +24,9 @@ CORS(app, origins=["https://my-wordpress.example"])
 ```
 
 Replace the URL with that of your WordPress site. The `Access-Control-Allow-Origin` header will contain this domain so file uploads from the plugin work correctly.
+
+## File size limit
+
+`api_server.py` rejects files larger than 100 MB. The constant `MAX_FILE_SIZE`
+defines this limit and the server checks `request.content_length` before saving
+the upload. Clients should keep individual WAV files under this size.


### PR DESCRIPTION
## Summary
- enforce 100 MB upload limit in `api_server.py`
- document file size limit in API docs

## Testing
- `python -m py_compile Audio_Training/scripts/api_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68531a98d5508333b15b86a413bc68ce