### PR TITLE
Clarify upload limits in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ depending on your deployment; the application works with both.
 The home page exposes a form for manual tests.
 When a WAV file is submitted, the server posts it to this API and
 displays the JSON response.
-Uploads larger than 100 MB are rejected and each user may store up to
-10 GB of audio in the database.
+
+Each upload may be up to 100 MB. The server also keeps track of the
+storage used by every account and refuses new files once a user reaches
+10 GB in total.
 
 ### Example Nginx configuration
 

--- a/docs/en/flask_app.md
+++ b/docs/en/flask_app.md
@@ -41,9 +41,11 @@ pred = Prediction(
 )
 ```
 
-`file_size` stores the uploaded file's size in bytes. The application rejects
-files larger than 100 MB and prevents each user from uploading more than
-10 GB in total.
+`file_size` stores the uploaded file's size in bytes.
+
+### Upload limits
+
+The application rejects files larger than 100 MB and prevents each user from uploading more than 10 GB in total.
 
 The history displayed on the home page therefore only shows the predictions of the active user.
 

--- a/docs/en/wordpress_plugin.md
+++ b/docs/en/wordpress_plugin.md
@@ -62,3 +62,7 @@ wp option update ns_api_endpoint https://your-vps.example/api/predict
 The API may reside on a different server than WordPress. If so, ensure
 that CORS is allowed and use HTTPS when required so the browser is able to
 post the files successfully.
+
+Uploads are subject to the same limits as the Flask form: each WAV file
+may be up to 100\u00a0MB and a given user cannot store more than
+10\u00a0GB in total.


### PR DESCRIPTION
## Summary
- elaborate on upload size and quota in README
- add an explicit Upload limits section in flask_app docs
- document file and quota limits for the WordPress audio upload plugin

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68531c489e908333ad7b8fe4818ac148