### PR TITLE
Add note on PHP upload limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,7 @@ Your WordPress site can run on a different host from the prediction
 server. Enable CORS in `Audio_Training/scripts/api_server.py` so your
 WordPress domain is allowed (see `docs/en/api_server.md`). HTTPS is also
 recommended so uploads succeed.
+
+WordPress may enforce stricter file size limits via PHP. In `php.ini`,
+set `upload_max_filesize` and `post_max_size` to at least `100M` so the
+plugin can accept files up to 100 MB.

--- a/docs/en/wordpress_plugin.md
+++ b/docs/en/wordpress_plugin.md
@@ -66,3 +66,8 @@ post the files successfully.
 Uploads are subject to the same limits as the Flask form: each WAV file
 may be up to 100\u00a0MB and a given user cannot store more than
 10\u00a0GB in total.
+
+WordPress itself can block large uploads if PHP is configured with small
+limits. Check the `upload_max_filesize` and `post_max_size` values in your
+`php.ini`. Both must be set to at least `100M` so the plugin can accept
+files up to 100 MB.


### PR DESCRIPTION
## Summary
- document that WordPress can block uploads when PHP's limits are lower than the plugin's 100 MB cap

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6854f3cfc67c83339ab7e54f3375116e