### PR TITLE
Improve API upload validation

### DIFF
--- a/Audio_Training/scripts/api_server.py
+++ b/Audio_Training/scripts/api_server.py
@@ -87,15 +87,24 @@ def api_predict():
         return jsonify({"error": "No file uploaded"}), 400
     if not file.filename.lower().endswith(".wav"):
         return jsonify({"error": "WAV file required"}), 400
+    if file.mimetype not in ("audio/wav", "audio/x-wav"):
+        return jsonify({"error": "Invalid content type"}), 400
     if request.content_length is not None and request.content_length > MAX_FILE_SIZE:
         return jsonify({"error": "File exceeds 100 MB limit"}), 400
     with tempfile.NamedTemporaryFile(suffix=".wav") as tmp:
-        file.save(tmp.name)
-        tmp.flush()
-        if request.content_length is None:
-            tmp.seek(0, 2)
-            if tmp.tell() > MAX_FILE_SIZE:
+        total = 0
+        while True:
+            chunk = file.stream.read(8192)
+            if not chunk:
+                break
+            tmp.write(chunk)
+            total += len(chunk)
+            if total > MAX_FILE_SIZE:
+                tmp.close()
                 return jsonify({"error": "File exceeds 100 MB limit"}), 400
+        tmp.flush()
+        if request.content_length is None and total > MAX_FILE_SIZE:
+            return jsonify({"error": "File exceeds 100 MB limit"}), 400
         results = predict_file(Path(tmp.name))
     return jsonify(results)
 


### PR DESCRIPTION
## Summary
- validate MIME type for uploaded audio
- stream audio data in chunks to check the 100 MB limit

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853b8779cb08333b3081c6b7b615f10