### PR TITLE
Add gunicorn to Python requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ Flask-Login
 Flask-SQLAlchemy
 requests
 pymysql
+gunicorn


### PR DESCRIPTION
## Summary
- include `gunicorn` in `requirements.txt`
- confirm setup script already installs from `requirements.txt`

## Testing
- `bash -n setup_vps_infomaniak.sh`
- `pip install gunicorn`
- `pip uninstall -y gunicorn`

------
https://chatgpt.com/codex/tasks/task_e_6854f9ff2a4c83338ed8acf0c7a7c602