### PR TITLE
Add create_app and gunicorn instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Launch it inside the virtual environment:
 ```bash
 source env/bin/activate
 python web/app.py
+# or with Gunicorn for production
+gunicorn -w 4 -b 0.0.0.0:8000 web.app:application
 ```
 
 The application connects to a MySQL database to store predictions for each

--- a/docs/en/flask_app.md
+++ b/docs/en/flask_app.md
@@ -69,4 +69,6 @@ Example:
 export SECRET_KEY="change-me"
 export PREDICT_API_URL="http://myserver:8001/api/predict"
 python web/app.py
+# or start with Gunicorn
+gunicorn -w 4 -b 0.0.0.0:8000 web.app:application
 ```

--- a/web/app.py
+++ b/web/app.py
@@ -169,7 +169,15 @@ def index():
     return render_template("index.html", result=result, predictions=predictions)
 
 
-if __name__ == "__main__":
+def create_app():
+    """Initialize the database and return the Flask app."""
     with app.app_context():
         db.create_all()
-    app.run(host="0.0.0.0", port=8000)
+    return app
+
+
+application = create_app()
+
+
+if __name__ == "__main__":
+    create_app().run(host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- make `web` a Python package
- add `create_app()` helper in `web/app.py`
- document Gunicorn usage

## Testing
- `python -m py_compile web/app.py`
- `python -m py_compile web/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6854fb7f71608333a92a13535c00637e