### PR TITLE
Enable Gunicorn for audio API

### DIFF
--- a/Audio_Training/__init__.py
+++ b/Audio_Training/__init__.py
@@ -1,0 +1,1 @@
+# Package for audio processing and training scripts

--- a/Audio_Training/scripts/__init__.py
+++ b/Audio_Training/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Subpackage with CLI scripts and API server

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ To start a local API using the trained model, run:
 python Audio_Training/scripts/api_server.py \
   --model_path models/best_model.pth \
   --csv_dir data/processed/csv
+# or with Gunicorn for production
+gunicorn -w 4 -b 0.0.0.0:8001 Audio_Training.scripts.api_server:application
 ```
 
 `web/app.py` expects this API to listen on `http://localhost:8001/api/predict`

--- a/docs/en/api_server.md
+++ b/docs/en/api_server.md
@@ -10,6 +10,9 @@ Activate the virtual environment then run:
 python Audio_Training/scripts/api_server.py \
   --model_path models/best_model.pth \
   --csv_dir data/processed/csv
+# or start with Gunicorn
+gunicorn -w 4 -b 0.0.0.0:8001 Audio_Training.scripts.api_server:application
+```
 ```
 
 By default the API listens on `0.0.0.0:8001`. The `--host` and `--port` options let you change this address. Make sure not to reuse the Flask app's port to avoid conflicts.


### PR DESCRIPTION
## Summary
- package Audio_Training and its scripts for module imports
- expose `create_app()` and `application` in API server
- support MODEL_PATH and CSV_DIR env vars
- document running API with Gunicorn

## Testing
- `python -m py_compile Audio_Training/scripts/api_server.py`
- `python -m py_compile Audio_Training/__init__.py Audio_Training/scripts/__init__.py`
- `python -m py_compile web/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6854fd683e9883338887633a09d37a9e