### PR TITLE
Improve Gunicorn setup docs

### DIFF
--- a/docs/en/api_server.md
+++ b/docs/en/api_server.md
@@ -4,15 +4,14 @@ This module provides a small Flask server exposing the `POST /api/predict` endpo
 
 ## Launch the server
 
-Activate the virtual environment then run:
+Activate the virtual environment. Install `gunicorn` if needed and then run:
 
 ```bash
-python Audio_Training/scripts/api_server.py \
-  --model_path models/best_model.pth \
-  --csv_dir data/processed/csv
-# or start with Gunicorn
-gunicorn -w 4 -b 0.0.0.0:8001 Audio_Training.scripts.api_server:application
-```
+pip install gunicorn
+export MODEL_PATH="models/best_model.pth"
+export CSV_DIR="data/processed/csv"
+gunicorn -w 4 -b 0.0.0.0:8001 \
+  Audio_Training.scripts.api_server:application
 ```
 
 By default the API listens on `0.0.0.0:8001`. The `--host` and `--port` options let you change this address. Make sure not to reuse the Flask app's port to avoid conflicts.
@@ -33,3 +32,6 @@ Replace the URL with that of your WordPress site. The `Access-Control-Allow-Orig
 `api_server.py` rejects files larger than 100 MB. The constant `MAX_FILE_SIZE`
 defines this limit and the server checks `request.content_length` before saving
 the upload. Clients should keep individual WAV files under this size.
+
+Just like the Flask web app, you should place a reverse proxy (for example
+Nginx) in front of Gunicorn and forward requests to port `8001`.

--- a/docs/en/flask_app.md
+++ b/docs/en/flask_app.md
@@ -63,12 +63,14 @@ Before starting the Flask server, define two variables:
 - `SECRET_KEY`: used to sign the session. Choose a random value in production.
 - `PREDICT_API_URL`: URL of the API that receives the files to analyze. If not set, `web/app.py` defaults to `http://localhost:8001/api/predict`. This variable may use either `http://` or `https://` depending on your API's configuration.
 
-Example:
+Example (install `gunicorn` if it is not already available):
 
 ```bash
+pip install gunicorn
 export SECRET_KEY="change-me"
 export PREDICT_API_URL="http://myserver:8001/api/predict"
-python web/app.py
-# or start with Gunicorn
 gunicorn -w 4 -b 0.0.0.0:8000 web.app:application
 ```
+
+In production you should place a reverse proxy such as Nginx in front of the
+Gunicorn workers and forward requests to port `8000`.


### PR DESCRIPTION
## Summary
- document using gunicorn in README and docs
- show how to set MODEL_PATH and CSV_DIR when starting the API
- explain that nginx should proxy requests to the gunicorn workers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685502d871f483338a82a0f58915cbaf