### PR TITLE
Handle invalid WAV uploads

### DIFF
--- a/Audio_Training/scripts/api_server.py
+++ b/Audio_Training/scripts/api_server.py
@@ -18,6 +18,8 @@ from pathlib import Path
 from typing import List, Dict, Optional
 import pathlib
 import os
+from pydub import AudioSegment
+from pydub.exceptions import CouldntDecodeError
 
 MAX_FILE_SIZE = 100 * 1024 * 1024  # 100 MB limit for uploads
 
@@ -125,6 +127,10 @@ def api_predict():
         tmp.flush()
         if request.content_length is None and total > MAX_FILE_SIZE:
             return jsonify({"error": "File exceeds 100 MB limit"}), 400
+        try:
+            AudioSegment.from_file(tmp.name)
+        except CouldntDecodeError:
+            return jsonify({"error": "Invalid WAV file"}), 400
         results = predict_file(Path(tmp.name))
     return jsonify(results)
 

--- a/docs/en/api_server.md
+++ b/docs/en/api_server.md
@@ -33,5 +33,9 @@ Replace the URL with that of your WordPress site. The `Access-Control-Allow-Orig
 defines this limit and the server checks `request.content_length` before saving
 the upload. Clients should keep individual WAV files under this size.
 
+Malformed or truncated WAV files are also rejected. The server attempts to open
+the uploaded data before running the model and returns a 400 error when the file
+cannot be decoded.
+
 Just like the Flask web app, you should place a reverse proxy (for example
 Nginx) in front of Gunicorn and forward requests to port `8001`.


### PR DESCRIPTION
## Summary
- validate uploaded WAV files in `api_server.py`
- mention in the docs that malformed WAV files are rejected

## Testing
- `python -m py_compile Audio_Training/scripts/api_server.py`


------
https://chatgpt.com/codex/tasks/task_e_685509129028833386ba9da9e1458c80