### PR TITLE
Fix Chart.js protocol issue

### DIFF
--- a/wp-plugin/prediction-charts/prediction-charts.php
+++ b/wp-plugin/prediction-charts/prediction-charts.php
@@ -8,8 +8,8 @@ Version: 1.0
 if (!defined('ABSPATH')) exit;
 
 function pc_enqueue_scripts() {
-    // Load Chart.js with a scheme-relative URL so the plugin works on HTTP and HTTPS
-    wp_enqueue_script('chartjs', '//cdn.jsdelivr.net/npm/chart.js', array(), null, true);
+    // Load Chart.js explicitly over HTTPS to avoid scheme-relative URLs
+    wp_enqueue_script('chartjs', 'https://cdn.jsdelivr.net/npm/chart.js', array(), null, true);
 }
 add_action('wp_enqueue_scripts', 'pc_enqueue_scripts');
 


### PR DESCRIPTION
## Summary
- ensure Chart.js is enqueued via an explicit HTTPS URL

## Testing
- `php -l wp-plugin/prediction-charts/prediction-charts.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68550b01a8dc8333a01eda04f76a5fa2