### PR TITLE
Add note about 0.0.0.0 binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ export PREDICT_API_URL="http://myserver:8001/api/predict"
 gunicorn -w 4 -b 0.0.0.0:8000 web.app:application
 ```
 
+The command above binds the web server to `0.0.0.0`, exposing it on every network interface. This is typical when running behind a reverse proxy or with firewall rules in place. If you prefer to keep the service private, bind to `127.0.0.1` or block the port using a firewall such as `ufw`.
+
 The application connects to a MySQL database to store predictions for each
 authenticated user. Configure the connection string with the
 `SQLALCHEMY_DATABASE_URI` environment variable if you need custom credentials or
@@ -62,7 +64,10 @@ export MODEL_PATH="models/best_model.pth"
 export CSV_DIR="data/processed/csv"
 gunicorn -w 4 -b 0.0.0.0:8001 \
   Audio_Training.scripts.api_server:application
+
 ```
+
+Like the web app, this command listens on `0.0.0.0` so the API is reachable from any interface. Behind a proxy or with firewall rules this is fine. Otherwise consider binding to `127.0.0.1` or restricting the port with a firewall.
 
 `web/app.py` expects this API to listen on `http://localhost:8001/api/predict`
 unless you override `PREDICT_API_URL`.

--- a/docs/en/api_server.md
+++ b/docs/en/api_server.md
@@ -16,6 +16,9 @@ gunicorn -w 4 -b 0.0.0.0:8001 \
 
 By default the API listens on `0.0.0.0:8001`. The `--host` and `--port` options let you change this address. Make sure not to reuse the Flask app's port to avoid conflicts.
 
+Listening on `0.0.0.0` means the API accepts connections from any interface. When running behind a reverse proxy or a firewall this is generally expected. If you do not want the service to be reachable from outside, bind it to `127.0.0.1` or restrict access with firewall rules (for example using `ufw`).
+
+
 ## Allow the WordPress domain
 
 If the API is called from a third-party site, the browser will reject the

--- a/docs/en/flask_app.md
+++ b/docs/en/flask_app.md
@@ -74,3 +74,9 @@ gunicorn -w 4 -b 0.0.0.0:8000 web.app:application
 
 In production you should place a reverse proxy such as Nginx in front of the
 Gunicorn workers and forward requests to port `8000`.
+
+The command above binds the server to `0.0.0.0`, which makes the application
+reachable from any network interface. When you deploy behind a reverse proxy or
+have a firewall restricting access, this is normally fine. If you want the
+service to be accessible only locally, change the host to `127.0.0.1` or add
+appropriate firewall rules.


### PR DESCRIPTION
## Summary
- document why the web app and API bind to `0.0.0.0`
- explain how to restrict access with firewall or by binding to `127.0.0.1`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685516843ce48333ad5cb48b4a5a11b5