### PR TITLE
Add CSRF protection to web forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ with Gunicorn rather than the built in Flask runner:
 source env/bin/activate
 pip install gunicorn
 export SECRET_KEY="change-me"
+export WTF_CSRF_SECRET_KEY="$SECRET_KEY"  # optional
 export PREDICT_API_URL="http://myserver:8001/api/predict"
 gunicorn -w 4 -b 0.0.0.0:8000 web.app:application
 ```
@@ -55,6 +56,8 @@ routes and database initialization.
 Set the `PREDICT_API_URL` environment variable to point to your
 prediction service. You must also define `SECRET_KEY` to configure the
 Flask session signing; use a random string for production.
+`Flask-WTF` provides CSRF protection. It will reuse `SECRET_KEY` unless you
+set a dedicated `WTF_CSRF_SECRET_KEY` variable.
 To start the prediction API, define the path to the trained model and the
 directory containing the training CSV files, then launch the server with
 Gunicorn:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ tqdm
 Flask
 Flask-Login
 Flask-SQLAlchemy
+Flask-WTF
 requests
 pymysql
 gunicorn

--- a/web/app.py
+++ b/web/app.py
@@ -11,6 +11,7 @@ from flask import (
     url_for,
 )
 from flask_sqlalchemy import SQLAlchemy
+from flask_wtf.csrf import CSRFProtect
 from flask_login import (
     LoginManager,
     login_user,
@@ -26,6 +27,8 @@ secret_key = os.environ.get("SECRET_KEY")
 if not secret_key:
     raise RuntimeError("SECRET_KEY environment variable not set")
 app.secret_key = secret_key
+app.config["WTF_CSRF_SECRET_KEY"] = os.environ.get("WTF_CSRF_SECRET_KEY", secret_key)
+csrf = CSRFProtect(app)
 db_uri = os.environ.get(
     "SQLALCHEMY_DATABASE_URI",
     "mysql+pymysql://user:password@localhost/nightscan",

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -9,6 +9,7 @@
   {% if current_user.is_authenticated %}
   <p>Logged in as {{ current_user.username }} | <a href="{{ url_for('logout') }}">Logout</a></p>
   <form action="/" method="post" enctype="multipart/form-data">
+    {{ csrf_token() }}
     <input type="file" name="file" accept="audio/wav" required>
     <p>Maximum 100 MB per file, 10 GB total for your account. WAV files only.</p>
     <input type="submit" value="Analyze">

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -7,6 +7,7 @@
 <body>
   <h1>Login</h1>
   <form method="post">
+    {{ csrf_token() }}
     <input type="text" name="username" placeholder="Username" required>
     <input type="password" name="password" placeholder="Password" required>
     <input type="submit" value="Login">

--- a/web/templates/register.html
+++ b/web/templates/register.html
@@ -7,6 +7,7 @@
 <body>
   <h1>Register</h1>
   <form method="post">
+    {{ csrf_token() }}
     <input type="text" name="username" placeholder="Username" required>
     <input type="password" name="password" placeholder="Password" required>
     <input type="submit" value="Register">


### PR DESCRIPTION
## Summary
- add `Flask-WTF` dependency
- initialize `CSRFProtect` in the Flask app
- include `{{ csrf_token() }}` in login, register and upload forms
- document optional `WTF_CSRF_SECRET_KEY` in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68551ce5cd588333bdb5c04441429957