### PR TITLE
Fix flake8 errors and cleanup preprocessing

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501,E402,W503

--- a/Audio_Training/scripts/api_server.py
+++ b/Audio_Training/scripts/api_server.py
@@ -20,9 +20,6 @@ import pathlib
 import os
 from pydub import AudioSegment
 from pydub.exceptions import CouldntDecodeError
-
-MAX_FILE_SIZE = 100 * 1024 * 1024  # 100 MB limit for uploads
-
 from flask import Flask, request, jsonify
 import torch
 from torch.utils.data import DataLoader
@@ -32,11 +29,13 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parent))
 
 import predict
 
+MAX_FILE_SIZE = 100 * 1024 * 1024  # 100 MB limit for uploads
+
 app = Flask(__name__)
 
-model: torch.nn.Module
-labels: List[str]
-device: torch.device
+model: torch.nn.Module | None = None
+labels: List[str] | None = None
+device: torch.device | None = None
 
 
 def load_model(model_path: Path, csv_dir: Path) -> None:

--- a/Audio_Training/scripts/preprocess.py
+++ b/Audio_Training/scripts/preprocess.py
@@ -243,8 +243,8 @@ def split_and_save(
 
     splits = {
         "train": files[:n_train],
-        "val": files[n_train : n_train + n_val],
-        "test": files[n_train + n_val :],
+        "val": files[n_train:n_train + n_val],
+        "test": files[n_train + n_val:],
     }
 
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -300,7 +300,7 @@ def main() -> None:
 
     copy_wav_files(args.input_dir, wav_dir)
 
-    processed_paths = process_wav_files(
+    process_wav_files(
         wav_dir,
         processed_dir,
         args.workers,

--- a/Picture_Training/scripts/prepare_csv.py
+++ b/Picture_Training/scripts/prepare_csv.py
@@ -34,8 +34,8 @@ def split_files(files: Sequence[Path], train: float, val: float, *, seed: int | 
     n_val = int(n_total * val)
     return {
         "train": files[:n_train],
-        "val": files[n_train : n_train + n_val],
-        "test": files[n_train + n_val :],
+        "val": files[n_train:n_train + n_val],
+        "test": files[n_train + n_val:],
     }
 
 


### PR DESCRIPTION
## Summary
- clean up unused variable in `preprocess.py`
- ensure API server variables are defined
- adjust slice spacing in `prepare_csv.py`
- configure flake8 and ignore some style rules

## Testing
- `flake8 && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_68551e4797508333910d4817cbd8c49f