### PR TITLE
Update documentation to stress HTTPS usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,16 @@ source env/bin/activate
 pip install gunicorn
 export SECRET_KEY="change-me"
 export WTF_CSRF_SECRET_KEY="$SECRET_KEY"  # optional
-export PREDICT_API_URL="http://myserver:8001/api/predict"
+export PREDICT_API_URL="https://myserver.example/api/predict"
 gunicorn -w 4 -b 0.0.0.0:8000 web.app:application
 ```
 
 The command above binds the web server to `0.0.0.0`, exposing it on every network interface. This is typical when running behind a reverse proxy or with firewall rules in place. If you prefer to keep the service private, bind to `127.0.0.1` or block the port using a firewall such as `ufw`.
 
 The application connects to a MySQL database to store predictions for each
-authenticated user. Configure the connection string with the
-`SQLALCHEMY_DATABASE_URI` environment variable if you need custom credentials or
-want to switch to another backend such as SQLite.
+authenticated user. Provide strong credentials via the
+`SQLALCHEMY_DATABASE_URI` environment variable and adjust the URI if you want to
+switch to another backend such as SQLite.
 See [`docs/en/flask_app.md`](docs/en/flask_app.md) for details on the login
 routes and database initialization.
 
@@ -74,8 +74,8 @@ Like the web app, this command listens on `0.0.0.0` so the API is reachable from
 
 `web/app.py` expects this API to listen on `http://localhost:8001/api/predict`
 unless you override `PREDICT_API_URL`.
-You can point `PREDICT_API_URL` to either an `http://` or `https://` endpoint
-depending on your deployment; the application works with both.
+For production deployments set `PREDICT_API_URL` to an `https://` endpoint so
+uploads are encrypted in transit.
 The home page exposes a form for manual tests.
 When a WAV file is submitted, the server posts it to this API and
 displays the JSON response.
@@ -102,6 +102,8 @@ server {
 This forwards HTTP requests to the Gunicorn workers listening on port 8000.
 Use a similar block for the API server on port 8001 so all traffic goes
 through the reverse proxy.
+When exposing the service to the internet, terminate HTTPS at the proxy so both
+the web app and prediction API are accessed securely.
 
 ## Quick prediction test
 

--- a/docs/en/flask_app.md
+++ b/docs/en/flask_app.md
@@ -12,6 +12,7 @@ with app.app_context():
 ```
 
 The `user` and `prediction` tables are generated from the models defined in `app.py`. If you prefer a local SQLite database for testing, set `SQLALCHEMY_DATABASE_URI` to something like `sqlite:///site.db` before running the app.
+For public deployments supply secure credentials in `SQLALCHEMY_DATABASE_URI` so the database cannot be accessed with default passwords.
 
 ## Login and registration routes
 
@@ -61,14 +62,14 @@ database.
 Before starting the Flask server, define two variables:
 
 - `SECRET_KEY`: used to sign the session. Choose a random value in production.
-- `PREDICT_API_URL`: URL of the API that receives the files to analyze. If not set, `web/app.py` defaults to `http://localhost:8001/api/predict`. This variable may use either `http://` or `https://` depending on your API's configuration.
+- `PREDICT_API_URL`: URL of the API that receives the files to analyze. If not set, `web/app.py` defaults to `http://localhost:8001/api/predict`. The application accepts either scheme, but in production use an `https://` endpoint.
 
 Example (install `gunicorn` if it is not already available):
 
 ```bash
 pip install gunicorn
 export SECRET_KEY="change-me"
-export PREDICT_API_URL="http://myserver:8001/api/predict"
+export PREDICT_API_URL="https://myserver.example/api/predict"
 gunicorn -w 4 -b 0.0.0.0:8000 web.app:application
 ```
 
@@ -79,4 +80,6 @@ The command above binds the server to `0.0.0.0`, which makes the application
 reachable from any network interface. When you deploy behind a reverse proxy or
 have a firewall restricting access, this is normally fine. If you want the
 service to be accessible only locally, change the host to `127.0.0.1` or add
-appropriate firewall rules.
+appropriate firewall rules. When the app is accessible on the public Internet
+you should enable HTTPS so login credentials and uploads are protected in
+transit.


### PR DESCRIPTION
## Summary
- recommend https endpoint for `PREDICT_API_URL`
- note secure database credentials
- advise using HTTPS when exposing the web app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68565d3cb3f48333bc130fa03b721ff5