### PR TITLE
Remove DB URI default and add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ gunicorn -w 4 -b 0.0.0.0:8000 web.app:application
 
 The command above binds the web server to `0.0.0.0`, exposing it on every network interface. This is typical when running behind a reverse proxy or with firewall rules in place. If you prefer to keep the service private, bind to `127.0.0.1` or block the port using a firewall such as `ufw`.
 
-The application connects to a MySQL database to store predictions for each
-authenticated user. Provide strong credentials via the
-`SQLALCHEMY_DATABASE_URI` environment variable and adjust the URI if you want to
-switch to another backend such as SQLite.
+The application connects to a database using the URL in
+`SQLALCHEMY_DATABASE_URI`. This variable is **mandatory**—`create_app()` raises
+`RuntimeError` when it is missing. Provide secure credentials in the URI and
+adjust it if you want to switch to another backend such as SQLite.
 See [`docs/en/flask_app.md`](docs/en/flask_app.md) for details on the login
 routes and database initialization.
 

--- a/docs/en/flask_app.md
+++ b/docs/en/flask_app.md
@@ -4,7 +4,7 @@ This document briefly explains how the web app in the `web/` folder works.
 
 ## Configuring the database
 
-When the app starts (`python web/app.py`), Flask connects to the database specified by the `SQLALCHEMY_DATABASE_URI` environment variable. By default it uses MySQL:
+When the app starts (`python web/app.py`) it expects the `SQLALCHEMY_DATABASE_URI` environment variable to be defined. `create_app()` raises `RuntimeError` if it is missing. Use a URI containing secure credentials appropriate for your database backend:
 
 ```python
 with app.app_context():

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -1,0 +1,23 @@
+import types
+from pathlib import Path
+import sys
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def load_app_module():
+    path = Path(__file__).resolve().parents[1] / "web" / "app.py"
+    source = path.read_text().replace("application = create_app()", "# application = create_app()")
+    module = types.ModuleType("flask_app_test")
+    module.__file__ = str(path)
+    exec(compile(source, str(path), "exec"), module.__dict__)
+    return module
+
+
+def test_create_app_requires_database_uri(monkeypatch):
+    monkeypatch.delenv("SQLALCHEMY_DATABASE_URI", raising=False)
+    monkeypatch.setenv("SECRET_KEY", "test")
+    module = load_app_module()
+    with pytest.raises(RuntimeError):
+        module.create_app()

--- a/web/app.py
+++ b/web/app.py
@@ -29,14 +29,9 @@ if not secret_key:
 app.secret_key = secret_key
 app.config["WTF_CSRF_SECRET_KEY"] = os.environ.get("WTF_CSRF_SECRET_KEY", secret_key)
 csrf = CSRFProtect(app)
-db_uri = os.environ.get(
-    "SQLALCHEMY_DATABASE_URI",
-    "mysql+pymysql://user:password@localhost/nightscan",
-)
-app.config["SQLALCHEMY_DATABASE_URI"] = db_uri
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
-db = SQLAlchemy(app)
+db = SQLAlchemy()
 
 MAX_FILE_SIZE = 100 * 1024 * 1024  # 100 MB per upload
 MAX_TOTAL_SIZE = 10 * 1024 * 1024 * 1024  # 10 GB per user
@@ -174,6 +169,11 @@ def index():
 
 def create_app():
     """Initialize the database and return the Flask app."""
+    db_uri = os.environ.get("SQLALCHEMY_DATABASE_URI")
+    if not db_uri:
+        raise RuntimeError("SQLALCHEMY_DATABASE_URI environment variable not set")
+    app.config["SQLALCHEMY_DATABASE_URI"] = db_uri
+    db.init_app(app)
     with app.app_context():
         db.create_all()
     return app


### PR DESCRIPTION
## Summary
- require `SQLALCHEMY_DATABASE_URI` in `web/app.py`
- document the mandatory environment variable
- describe secure database credentials in README
- test that `create_app()` fails if the variable is missing

## Testing
- `pip install flask flask-sqlalchemy flask-login flask-wtf requests pymysql pydub torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu`
- `pip install audioop-lts pyaudio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856617d3c288333acc3732e2ef4a9c8