### PR TITLE
Handle prediction errors

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -158,7 +158,8 @@ def index():
                         db.session.add(pred)
                         db.session.commit()
                     except requests.RequestException as e:
-                        flash(f"Prediction error: {e}")
+                        app.logger.error("Prediction request failed: %s", e)
+                        flash("Prediction failed. Please try again later.")
     predictions = (
         Prediction.query.filter_by(user_id=current_user.id)
         .order_by(Prediction.id.desc())


### PR DESCRIPTION
## Summary
- log prediction API errors
- show a generic error message on failures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68585276fa6483338a3aa31276f525ce