### PR TITLE
Add Flask-Talisman security middleware

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ Flask==3.1.1
 Flask-Login==0.6.3
 Flask-SQLAlchemy==3.1.1
 Flask-WTF==1.2.2
+flask-talisman==1.1.0
 fsspec==2025.5.1
 greenlet==3.2.3
 gunicorn==23.0.0

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -38,6 +38,8 @@ def test_index_rejects_bad_mimetype(monkeypatch, tmp_path):
         module.db.session.commit()
 
     client = app.test_client()
+    client.environ_base["wsgi.url_scheme"] = "https"
+    client.environ_base["HTTP_X_FORWARDED_PROTO"] = "https"
     client.post("/login", data={"username": "user", "password": "pass"})
 
     called = False

--- a/web/app.py
+++ b/web/app.py
@@ -20,6 +20,7 @@ from flask_login import (
     current_user,
     UserMixin,
 )
+from flask_talisman import Talisman
 from werkzeug.security import generate_password_hash, check_password_hash
 
 app = Flask(__name__)
@@ -32,6 +33,8 @@ csrf = CSRFProtect(app)
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
 db = SQLAlchemy()
+csp = {"default-src": "'self'"}
+Talisman(app, force_https=True, frame_options="DENY", content_security_policy=csp)
 
 MAX_FILE_SIZE = 100 * 1024 * 1024  # 100 MB per upload
 MAX_TOTAL_SIZE = 10 * 1024 * 1024 * 1024  # 10 GB per user


### PR DESCRIPTION
## Summary
- secure Flask app with Flask-Talisman
- record dependency in requirements
- adapt tests for HTTPS enforced by Talisman

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685856bfe1c48333bb59a10b4f8834d9