### PR TITLE
Add module docstrings to training and prediction scripts

### DIFF
--- a/Picture_Training/scripts/train.py
+++ b/Picture_Training/scripts/train.py
@@ -1,3 +1,11 @@
+"""Train a ResNet18 classifier on images listed in CSV files.
+
+The directory passed with ``--csv_dir`` must contain ``train.csv`` and
+``val.csv`` using ``path`` and ``label`` columns. The best weights are written
+to ``--model_dir``. Other useful options are ``--epochs``, ``--batch_size``,
+``--lr``, ``--num_workers`` and ``--pretrained`` to enable ImageNet weights.
+"""
+
 import argparse
 import csv
 from pathlib import Path
@@ -20,11 +28,15 @@ class ImageCsvDataset(Dataset):
             reader = csv.DictReader(f)
             for row in reader:
                 self.samples.append((Path(row["path"]), int(row["label"])))
-        self.transform = transforms.Compose([
-            transforms.Resize((224, 224)),
-            transforms.ToTensor(),
-            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
-        ])
+        self.transform = transforms.Compose(
+            [
+                transforms.Resize((224, 224)),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                ),
+            ]
+        )
 
     def __len__(self) -> int:
         return len(self.samples)
@@ -36,7 +48,9 @@ class ImageCsvDataset(Dataset):
         return img, label
 
 
-def train_epoch(model: nn.Module, loader: DataLoader, criterion, optimizer, device: torch.device) -> float:
+def train_epoch(
+    model: nn.Module, loader: DataLoader, criterion, optimizer, device: torch.device
+) -> float:
     model.train()
     running_loss = 0.0
     for inputs, targets in tqdm(loader, desc="Training", leave=False):
@@ -50,7 +64,9 @@ def train_epoch(model: nn.Module, loader: DataLoader, criterion, optimizer, devi
     return running_loss / len(loader.dataset)
 
 
-def evaluate(model: nn.Module, loader: DataLoader, criterion, device: torch.device) -> Tuple[float, float]:
+def evaluate(
+    model: nn.Module, loader: DataLoader, criterion, device: torch.device
+) -> Tuple[float, float]:
     model.eval()
     loss = 0.0
     correct = 0
@@ -66,24 +82,48 @@ def evaluate(model: nn.Module, loader: DataLoader, criterion, device: torch.devi
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Train ResNet18 on images")
-    parser.add_argument("--csv_dir", type=Path, required=True, help="Directory containing train.csv and val.csv")
-    parser.add_argument("--model_dir", type=Path, required=True, help="Where to save the trained model")
+    parser.add_argument(
+        "--csv_dir",
+        type=Path,
+        required=True,
+        help="Directory containing train.csv and val.csv",
+    )
+    parser.add_argument(
+        "--model_dir", type=Path, required=True, help="Where to save the trained model"
+    )
     parser.add_argument("--epochs", type=int, default=10)
     parser.add_argument("--batch_size", type=int, default=32)
     parser.add_argument("--lr", type=float, default=1e-3)
     parser.add_argument("--num_workers", type=int, default=0)
-    parser.add_argument("--pretrained", action="store_true", help="Use ImageNet pretrained weights")
+    parser.add_argument(
+        "--pretrained", action="store_true", help="Use ImageNet pretrained weights"
+    )
     args = parser.parse_args()
 
     train_ds = ImageCsvDataset(args.csv_dir / "train.csv")
     val_ds = ImageCsvDataset(args.csv_dir / "val.csv")
     num_classes = len(set(label for _, label in train_ds.samples))
 
-    device = torch.device("cuda" if torch.cuda.is_available() else ("mps" if torch.backends.mps.is_available() else "cpu"))
+    device = torch.device(
+        "cuda"
+        if torch.cuda.is_available()
+        else ("mps" if torch.backends.mps.is_available() else "cpu")
+    )
     pin_memory = device.type != "cpu"
 
-    train_loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True, num_workers=args.num_workers, pin_memory=pin_memory)
-    val_loader = DataLoader(val_ds, batch_size=args.batch_size, num_workers=args.num_workers, pin_memory=pin_memory)
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=args.num_workers,
+        pin_memory=pin_memory,
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+        pin_memory=pin_memory,
+    )
 
     weights = models.ResNet18_Weights.DEFAULT if args.pretrained else None
     model = models.resnet18(weights=weights)
@@ -98,7 +138,9 @@ def main() -> None:
     for epoch in range(1, args.epochs + 1):
         train_loss = train_epoch(model, train_loader, criterion, optimizer, device)
         val_loss, val_acc = evaluate(model, val_loader, criterion, device)
-        print(f"Epoch {epoch}: train_loss={train_loss:.4f} val_loss={val_loss:.4f} val_acc={val_acc:.4f}")
+        print(
+            f"Epoch {epoch}: train_loss={train_loss:.4f} val_loss={val_loss:.4f} val_acc={val_acc:.4f}"
+        )
         if val_acc > best_acc:
             best_acc = val_acc
             torch.save(model.state_dict(), args.model_dir / "best_model.pth")


### PR DESCRIPTION
## Summary
- document the purpose and main options in the audio and picture training scripts
- add docstrings to the audio and picture prediction scripts

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858eb256d9c833386e70d525cf8dbb1