### PR TITLE
Add initial iOS app skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,5 +203,6 @@ plugin can accept files up to 100 MB.
 ## App
 
 For instructions on building a mobile client in React Native, see
-[`docs/en/mobile_app.md`](docs/en/mobile_app.md).
+[`docs/en/mobile_app.md`](docs/en/mobile_app.md). A minimal starter
+project is included under [`ios-app/`](ios-app/).
 

--- a/docs/en/mobile_app.md
+++ b/docs/en/mobile_app.md
@@ -52,7 +52,9 @@ Ensure `node` and `watchman` are available in your PATH.
 
 ## Project initialization
 
-Create a new project and start the development server:
+Create a new project and start the development server. A very small starter
+project is already available in the repository under `ios-app/` if you want to
+skip this step:
 
 ```bash
 npx react-native init NightScanApp

--- a/ios-app/App.js
+++ b/ios-app/App.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { SafeAreaView, StyleSheet, Text } from 'react-native';
+
+function App() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.text}>Welcome to NightScan iOS</Text>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    fontSize: 18,
+  },
+});
+
+export default App;

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -1,0 +1,16 @@
+# NightScan iOS App
+
+This folder contains a barebones React Native application for iOS. It can also be
+extended to support Android.
+
+## Getting Started
+
+Install dependencies with `npm install` then start the Metro server:
+
+```bash
+cd ios-app
+npm install
+npm run ios
+```
+
+This assumes you have the React Native CLI and Xcode installed on your machine.

--- a/ios-app/app.json
+++ b/ios-app/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "NightScanApp",
+  "displayName": "NightScan"
+}

--- a/ios-app/index.js
+++ b/ios-app/index.js
@@ -1,0 +1,5 @@
+import {AppRegistry} from 'react-native';
+import App from './App';
+import {name as appName} from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/ios-app/package.json
+++ b/ios-app/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "NightScanApp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "react-native start",
+    "ios": "react-native run-ios"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.71.8"
+  }
+}


### PR DESCRIPTION
## Summary
- start a barebones React Native project under `ios-app/`
- reference this starter project from the README and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859981758348333ad4eeeab2529e990