### PR TITLE
Add navigation skeleton for iOS app

### DIFF
--- a/ios-app/App.js
+++ b/ios-app/App.js
@@ -1,23 +1,18 @@
 import React from 'react';
-import { SafeAreaView, StyleSheet, Text } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import HomeScreen from './screens/HomeScreen';
+import ScanScreen from './screens/ScanScreen';
 
-function App() {
+const Stack = createNativeStackNavigator();
+
+export default function App() {
   return (
-    <SafeAreaView style={styles.container}>
-      <Text style={styles.text}>Welcome to NightScan iOS</Text>
-    </SafeAreaView>
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Scan" component={ScanScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  text: {
-    fontSize: 18,
-  },
-});
-
-export default App;

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -1,11 +1,12 @@
 # NightScan iOS App
 
-This folder contains a barebones React Native application for iOS. It can also be
-extended to support Android.
+This folder contains a React Native application for iOS.
+It provides a basic navigation setup with a home screen and a scan screen.
+The application can also be extended to support Android.
 
 ## Getting Started
 
-Install dependencies with `npm install` then start the Metro server:
+Install dependencies and run the app using the React Native CLI:
 
 ```bash
 cd ios-app

--- a/ios-app/package.json
+++ b/ios-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NightScanApp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "start": "react-native start",
@@ -8,6 +8,10 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-native": "^0.71.8"
+    "react-native": "^0.71.8",
+    "@react-navigation/native": "^6.1.7",
+    "@react-navigation/native-stack": "^6.9.12",
+    "react-native-screens": "^3.22.0",
+    "react-native-safe-area-context": "^4.5.0"
   }
 }

--- a/ios-app/screens/HomeScreen.js
+++ b/ios-app/screens/HomeScreen.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { View, Text, StyleSheet, Button } from 'react-native';
+
+export default function HomeScreen({ navigation }) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Welcome to NightScan iOS</Text>
+      <Button
+        title="Start Scan"
+        onPress={() => navigation.navigate('Scan')}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: 18,
+    marginBottom: 12,
+  },
+});

--- a/ios-app/screens/ScanScreen.js
+++ b/ios-app/screens/ScanScreen.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function ScanScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Scanning placeholder...</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    fontSize: 18,
+  },
+});


### PR DESCRIPTION
## Summary
- add React Navigation stack to `App.js`
- create `HomeScreen` and `ScanScreen`
- update package.json with navigation deps
- document the simple navigation in the iOS README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a14dbc548333b4734d4672929c1b