### PR TITLE
Extend iOS app skeleton with map and detections

### DIFF
--- a/ios-app/App.js
+++ b/ios-app/App.js
@@ -3,6 +3,8 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import HomeScreen from './screens/HomeScreen';
 import ScanScreen from './screens/ScanScreen';
+import MapScreen from './screens/MapScreen';
+import DetectionListScreen from './screens/DetectionListScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -12,6 +14,8 @@ export default function App() {
       <Stack.Navigator>
         <Stack.Screen name="Home" component={HomeScreen} />
         <Stack.Screen name="Scan" component={ScanScreen} />
+        <Stack.Screen name="Map" component={MapScreen} />
+        <Stack.Screen name="Detections" component={DetectionListScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -2,6 +2,7 @@
 
 This folder contains a React Native application for iOS.
 It provides a basic navigation setup with a home screen and a scan screen.
+Additional placeholders include a map view and a detection list.
 The application can also be extended to support Android.
 
 ## Getting Started

--- a/ios-app/package.json
+++ b/ios-app/package.json
@@ -12,6 +12,7 @@
     "@react-navigation/native": "^6.1.7",
     "@react-navigation/native-stack": "^6.9.12",
     "react-native-screens": "^3.22.0",
-    "react-native-safe-area-context": "^4.5.0"
+    "react-native-safe-area-context": "^4.5.0",
+    "react-native-maps": "^1.6.0"
   }
 }

--- a/ios-app/screens/DetectionListScreen.js
+++ b/ios-app/screens/DetectionListScreen.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { View, Text, StyleSheet, FlatList } from 'react-native';
+
+const detections = [
+  { id: '1', species: 'Fox', time: '2025-06-01 22:15' },
+  { id: '2', species: 'Deer', time: '2025-06-01 22:30' },
+  { id: '3', species: 'Owl', time: '2025-06-01 23:00' },
+];
+
+export default function DetectionListScreen() {
+  const renderItem = ({ item }) => (
+    <View style={styles.item}>
+      <Text style={styles.species}>{item.species}</Text>
+      <Text style={styles.time}>{item.time}</Text>
+    </View>
+  );
+
+  return (
+    <FlatList
+      style={styles.list}
+      data={detections}
+      renderItem={renderItem}
+      keyExtractor={(item) => item.id}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  list: {
+    flex: 1,
+    padding: 16,
+  },
+  item: {
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: '#ccc',
+  },
+  species: {
+    fontSize: 16,
+  },
+  time: {
+    color: '#555',
+  },
+});

--- a/ios-app/screens/HomeScreen.js
+++ b/ios-app/screens/HomeScreen.js
@@ -9,6 +9,16 @@ export default function HomeScreen({ navigation }) {
         title="Start Scan"
         onPress={() => navigation.navigate('Scan')}
       />
+      <View style={styles.spacing} />
+      <Button
+        title="View Map"
+        onPress={() => navigation.navigate('Map')}
+      />
+      <View style={styles.spacing} />
+      <Button
+        title="View Detections"
+        onPress={() => navigation.navigate('Detections')}
+      />
     </View>
   );
 }
@@ -22,5 +32,8 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 18,
     marginBottom: 12,
+  },
+  spacing: {
+    height: 12,
   },
 });

--- a/ios-app/screens/MapScreen.js
+++ b/ios-app/screens/MapScreen.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import MapView, { Marker } from 'react-native-maps';
+
+export default function MapScreen() {
+  const markers = [
+    { id: 1, title: 'Fox', coordinate: { latitude: 37.78825, longitude: -122.4324 } },
+    { id: 2, title: 'Deer', coordinate: { latitude: 37.78925, longitude: -122.4344 } },
+  ];
+
+  return (
+    <View style={styles.container}>
+      <MapView
+        style={styles.map}
+        initialRegion={{
+          latitude: 37.78825,
+          longitude: -122.4324,
+          latitudeDelta: 0.0922,
+          longitudeDelta: 0.0421,
+        }}
+      >
+        {markers.map((m) => (
+          <Marker key={m.id} coordinate={m.coordinate} title={m.title} />
+        ))}
+      </MapView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  map: {
+    ...StyleSheet.absoluteFillObject,
+  },
+});


### PR DESCRIPTION
## Summary
- add placeholder map screen and detection list screen
- link screens from home via navigation stack
- document new screens in README
- add `react-native-maps` dependency

## Testing
- `pip install -q -r requirements-ci.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a350859883339c9b61300f378471