### PR TITLE
Add bottom tab navigation and tasks

### DIFF
--- a/ios-app/App.js
+++ b/ios-app/App.js
@@ -1,21 +1,35 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import HomeScreen from './screens/HomeScreen';
 import ScanScreen from './screens/ScanScreen';
 import MapScreen from './screens/MapScreen';
 import DetectionListScreen from './screens/DetectionListScreen';
 
 const Stack = createNativeStackNavigator();
+const Tab = createBottomTabNavigator();
+
+function MainTabs() {
+  return (
+    <Tab.Navigator>
+      <Tab.Screen name="Map" component={MapScreen} />
+      <Tab.Screen name="Detections" component={DetectionListScreen} />
+      <Tab.Screen name="Scan" component={ScanScreen} />
+    </Tab.Navigator>
+  );
+}
 
 export default function App() {
   return (
     <NavigationContainer>
       <Stack.Navigator>
         <Stack.Screen name="Home" component={HomeScreen} />
-        <Stack.Screen name="Scan" component={ScanScreen} />
-        <Stack.Screen name="Map" component={MapScreen} />
-        <Stack.Screen name="Detections" component={DetectionListScreen} />
+        <Stack.Screen
+          name="Main"
+          component={MainTabs}
+          options={{ headerShown: false }}
+        />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -1,8 +1,9 @@
 # NightScan iOS App
 
 This folder contains a React Native application for iOS.
-It provides a basic navigation setup with a home screen and a scan screen.
-Additional placeholders include a map view and a detection list.
+It provides a basic navigation setup with a home screen followed by a bottom tab
+interface. The tabs include the map, the detection list and a scan view.
+Additional placeholders can be filled in with authentication and settings.
 The application can also be extended to support Android.
 
 ## Getting Started

--- a/ios-app/TASKS.md
+++ b/ios-app/TASKS.md
@@ -1,0 +1,8 @@
+# iOS App Tasks
+
+- [ ] Integrate API service for fetching detections
+- [ ] Manage global app state with React context
+- [ ] Implement login and registration screens
+- [ ] Add push notifications for new detections
+- [ ] Provide offline caching of the detection list
+- [ ] Write basic unit tests for components

--- a/ios-app/package.json
+++ b/ios-app/package.json
@@ -11,6 +11,7 @@
     "react-native": "^0.71.8",
     "@react-navigation/native": "^6.1.7",
     "@react-navigation/native-stack": "^6.9.12",
+    "@react-navigation/bottom-tabs": "^6.5.8",
     "react-native-screens": "^3.22.0",
     "react-native-safe-area-context": "^4.5.0",
     "react-native-maps": "^1.6.0"


### PR DESCRIPTION
## Summary
- extend the iOS app navigation with bottom tabs
- document the new structure in the README
- list next steps in `TASKS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a534b65883339c5358a398a4ab64