### PR TITLE
Add detection detail screen

### DIFF
--- a/ios-app/App.js
+++ b/ios-app/App.js
@@ -6,6 +6,7 @@ import HomeScreen from './screens/HomeScreen';
 import ScanScreen from './screens/ScanScreen';
 import MapScreen from './screens/MapScreen';
 import DetectionListScreen from './screens/DetectionListScreen';
+import DetectionDetailScreen from './screens/DetectionDetailScreen';
 
 const Stack = createNativeStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -30,6 +31,7 @@ export default function App() {
           component={MainTabs}
           options={{ headerShown: false }}
         />
+        <Stack.Screen name="DetectionDetail" component={DetectionDetailScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/ios-app/TASKS.md
+++ b/ios-app/TASKS.md
@@ -6,7 +6,7 @@
 - [ ] Add push notifications for new detections
 - [ ] Provide offline caching of the detection list
 - [ ] Write basic unit tests for components
-- [ ] Implement a detection detail screen with map and photo
+- [x] Implement a detection detail screen with map and photo
 - [ ] Add search and filtering for the detection list
 - [ ] Create a settings screen and persist preferences
 - [ ] Support dark mode theming across the app

--- a/ios-app/screens/DetectionDetailScreen.js
+++ b/ios-app/screens/DetectionDetailScreen.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { View, Text, StyleSheet, Image } from 'react-native';
+import MapView, { Marker } from 'react-native-maps';
+
+export default function DetectionDetailScreen({ route }) {
+  const { detection } = route.params;
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{detection.species}</Text>
+      <Text style={styles.time}>{detection.time}</Text>
+      <MapView
+        style={styles.map}
+        initialRegion={{
+          latitude: detection.latitude,
+          longitude: detection.longitude,
+          latitudeDelta: 0.01,
+          longitudeDelta: 0.01,
+        }}
+      >
+        <Marker
+          coordinate={{
+            latitude: detection.latitude,
+            longitude: detection.longitude,
+          }}
+          title={detection.species}
+        />
+      </MapView>
+      <Image style={styles.image} source={{ uri: detection.image }} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    padding: 16,
+  },
+  time: {
+    paddingHorizontal: 16,
+    marginBottom: 8,
+  },
+  map: {
+    height: 200,
+  },
+  image: {
+    flex: 1,
+    resizeMode: 'contain',
+  },
+});

--- a/ios-app/screens/DetectionListScreen.js
+++ b/ios-app/screens/DetectionListScreen.js
@@ -1,18 +1,43 @@
 import React from 'react';
-import { View, Text, StyleSheet, FlatList } from 'react-native';
+import { View, Text, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
 
 const detections = [
-  { id: '1', species: 'Fox', time: '2025-06-01 22:15' },
-  { id: '2', species: 'Deer', time: '2025-06-01 22:30' },
-  { id: '3', species: 'Owl', time: '2025-06-01 23:00' },
+  {
+    id: '1',
+    species: 'Fox',
+    time: '2025-06-01 22:15',
+    latitude: 37.78825,
+    longitude: -122.4324,
+    image: 'https://via.placeholder.com/400',
+  },
+  {
+    id: '2',
+    species: 'Deer',
+    time: '2025-06-01 22:30',
+    latitude: 37.78925,
+    longitude: -122.4344,
+    image: 'https://via.placeholder.com/400',
+  },
+  {
+    id: '3',
+    species: 'Owl',
+    time: '2025-06-01 23:00',
+    latitude: 37.79025,
+    longitude: -122.4354,
+    image: 'https://via.placeholder.com/400',
+  },
 ];
 
-export default function DetectionListScreen() {
+export default function DetectionListScreen({ navigation }) {
   const renderItem = ({ item }) => (
-    <View style={styles.item}>
-      <Text style={styles.species}>{item.species}</Text>
-      <Text style={styles.time}>{item.time}</Text>
-    </View>
+    <TouchableOpacity
+      onPress={() => navigation.navigate('DetectionDetail', { detection: item })}
+    >
+      <View style={styles.item}>
+        <Text style={styles.species}>{item.species}</Text>
+        <Text style={styles.time}>{item.time}</Text>
+      </View>
+    </TouchableOpacity>
   );
 
   return (


### PR DESCRIPTION
## Summary
- add detection detail screen to ios app
- navigate from detection list to the new screen
- wire detection detail in the navigation stack
- mark the task as complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d21827ac8833383316a107428c7ec