### PR TITLE
Add basic Expo config for iOS app

### DIFF
--- a/ios-app/App.js
+++ b/ios-app/App.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
+import { StatusBar } from 'expo-status-bar';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import HomeScreen from './screens/HomeScreen';
@@ -33,6 +34,7 @@ export default function App() {
         />
         <Stack.Screen name="DetectionDetail" component={DetectionDetailScreen} />
       </Stack.Navigator>
+      <StatusBar style="auto" />
     </NavigationContainer>
   );
 }

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -8,12 +8,13 @@ The application can also be extended to support Android.
 
 ## Getting Started
 
-Install dependencies and run the app using the React Native CLI:
+Install dependencies and run the app using Expo:
 
 ```bash
 cd ios-app
 npm install
-npm run ios
+npx expo install react-native-maps
+npx expo start
 ```
+After the Metro bundler starts, scan the QR code in your terminal with the Expo Go app to launch NightScan on your device.
 
-This assumes you have the React Native CLI and Xcode installed on your machine.

--- a/ios-app/app.json
+++ b/ios-app/app.json
@@ -1,4 +1,9 @@
 {
-  "name": "NightScanApp",
-  "displayName": "NightScan"
+  "expo": {
+    "name": "NightScan",
+    "slug": "nightscan",
+    "version": "0.2.0",
+    "sdkVersion": "53.0.0",
+    "platforms": ["ios", "android"]
+  }
 }

--- a/ios-app/package.json
+++ b/ios-app/package.json
@@ -3,8 +3,8 @@
   "version": "0.2.0",
   "private": true,
   "scripts": {
-    "start": "react-native start",
-    "ios": "react-native run-ios"
+    "start": "expo start",
+    "ios": "expo start --ios"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -14,6 +14,11 @@
     "@react-navigation/bottom-tabs": "^6.5.8",
     "react-native-screens": "^3.22.0",
     "react-native-safe-area-context": "^4.5.0",
-    "react-native-maps": "^1.6.0"
+    "react-native-maps": "^1.6.0",
+    "expo": "^53.0.12",
+    "expo-status-bar": "^2.2.3"
+  },
+  "devDependencies": {
+    "expo-cli": "^6.3.10"
   }
 }


### PR DESCRIPTION
## Summary
- migrate React Native iOS app to Expo
- configure Expo in `app.json`
- update app entry to use `expo-status-bar`
- update README with Expo usage instructions

## Testing
- `pytest -q`
- `npx expo start --help` *(fails: needs package installation)*

------
https://chatgpt.com/codex/tasks/task_e_685d3a742e948333916bb464f8bde7ee