### PR TITLE
Add settings screen to iOS app

### DIFF
--- a/ios-app/App.js
+++ b/ios-app/App.js
@@ -10,6 +10,7 @@ import DetectionListScreen from './screens/DetectionListScreen';
 import DetectionDetailScreen from './screens/DetectionDetailScreen';
 import LoginScreen from './screens/LoginScreen';
 import RegisterScreen from './screens/RegisterScreen';
+import SettingsScreen from './screens/SettingsScreen';
 
 const Stack = createNativeStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -20,6 +21,7 @@ function MainTabs() {
       <Tab.Screen name="Map" component={MapScreen} />
       <Tab.Screen name="Detections" component={DetectionListScreen} />
       <Tab.Screen name="Scan" component={ScanScreen} />
+      <Tab.Screen name="Settings" component={SettingsScreen} />
     </Tab.Navigator>
   );
 }

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -14,6 +14,7 @@ Install dependencies and run the app using Expo:
 cd ios-app
 npm install
 npx expo install react-native-maps
+npx expo install @react-native-async-storage/async-storage
 npx expo start
 ```
 After the Metro bundler starts, scan the QR code in your terminal with the Expo Go app to launch NightScan on your device.

--- a/ios-app/TASKS.md
+++ b/ios-app/TASKS.md
@@ -8,6 +8,6 @@
 - [ ] Write basic unit tests for components
 - [x] Implement a detection detail screen with map and photo
 - [x] Add search and filtering for the detection list
-- [ ] Create a settings screen and persist preferences
+- [x] Create a settings screen and persist preferences
 - [ ] Support dark mode theming across the app
 - [ ] Configure Jest with React Native Testing Library

--- a/ios-app/package.json
+++ b/ios-app/package.json
@@ -16,7 +16,8 @@
     "react-native-safe-area-context": "^4.5.0",
     "react-native-maps": "^1.6.0",
     "expo": "^53.0.12",
-    "expo-status-bar": "^2.2.3"
+    "expo-status-bar": "^2.2.3",
+    "@react-native-async-storage/async-storage": "^1.23.0"
   },
   "devDependencies": {
     "expo-cli": "^6.3.10"

--- a/ios-app/screens/SettingsScreen.js
+++ b/ios-app/screens/SettingsScreen.js
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import { View, Switch, Text, StyleSheet } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const PREFS_KEY = 'settings';
+
+export default function SettingsScreen() {
+  const [darkMode, setDarkMode] = useState(false);
+  const [notifications, setNotifications] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const raw = await AsyncStorage.getItem(PREFS_KEY);
+        if (raw) {
+          const prefs = JSON.parse(raw);
+          setDarkMode(!!prefs.darkMode);
+          setNotifications(!!prefs.notifications);
+        }
+      } catch (e) {
+        // ignore read errors
+      }
+    }
+    load();
+  }, []);
+
+  useEffect(() => {
+    const prefs = { darkMode, notifications };
+    AsyncStorage.setItem(PREFS_KEY, JSON.stringify(prefs)).catch(() => {});
+  }, [darkMode, notifications]);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.row}>
+        <Text style={styles.label}>Dark Mode</Text>
+        <Switch value={darkMode} onValueChange={setDarkMode} />
+      </View>
+      <View style={styles.row}>
+        <Text style={styles.label}>Notifications</Text>
+        <Switch value={notifications} onValueChange={setNotifications} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 12,
+  },
+  label: {
+    fontSize: 16,
+  },
+});


### PR DESCRIPTION
## Summary
- add AsyncStorage dependency
- implement Settings screen with dark mode and notification toggles
- hook screen into bottom tabs
- update README instructions
- mark settings task complete

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_685d48cde7288333b5d594702aad5796