### PR TITLE
Implement detection API integration

### DIFF
--- a/ios-app/TASKS.md
+++ b/ios-app/TASKS.md
@@ -1,6 +1,6 @@
 # iOS App Tasks
 
-- [ ] Integrate API service for fetching detections
+- [x] Integrate API service for fetching detections
 - [x] Manage global app state with React context
 - [x] Implement login and registration screens
 - [ ] Add push notifications for new detections

--- a/ios-app/screens/DetectionListScreen.js
+++ b/ios-app/screens/DetectionListScreen.js
@@ -1,35 +1,16 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, FlatList, TouchableOpacity, TextInput } from 'react-native';
-
-const detections = [
-  {
-    id: '1',
-    species: 'Fox',
-    time: '2025-06-01 22:15',
-    latitude: 37.78825,
-    longitude: -122.4324,
-    image: 'https://via.placeholder.com/400',
-  },
-  {
-    id: '2',
-    species: 'Deer',
-    time: '2025-06-01 22:30',
-    latitude: 37.78925,
-    longitude: -122.4344,
-    image: 'https://via.placeholder.com/400',
-  },
-  {
-    id: '3',
-    species: 'Owl',
-    time: '2025-06-01 23:00',
-    latitude: 37.79025,
-    longitude: -122.4354,
-    image: 'https://via.placeholder.com/400',
-  },
-];
+import { fetchDetections } from '../services/api';
 
 export default function DetectionListScreen({ navigation }) {
+  const [detections, setDetections] = useState([]);
   const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    fetchDetections()
+      .then(setDetections)
+      .catch(() => {});
+  }, []);
 
   const filtered = detections.filter((d) =>
     d.species.toLowerCase().includes(query.toLowerCase())
@@ -58,7 +39,7 @@ export default function DetectionListScreen({ navigation }) {
         style={styles.list}
         data={filtered}
         renderItem={renderItem}
-        keyExtractor={(item) => item.id}
+        keyExtractor={(item) => item.id.toString()}
       />
     </View>
   );

--- a/ios-app/screens/LoginScreen.js
+++ b/ios-app/screens/LoginScreen.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { View, TextInput, Button, StyleSheet, Alert } from 'react-native';
-
-const BASE_URL = 'http://localhost:8000';
+import { login as loginRequest } from '../services/api';
 
 export default function LoginScreen({ navigation }) {
   const [username, setUsername] = useState('');
@@ -9,21 +8,10 @@ export default function LoginScreen({ navigation }) {
 
   const handleLogin = async () => {
     try {
-      const resp = await fetch(`${BASE_URL}/login`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: `username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
-        credentials: 'include',
-      });
-      if (resp.ok) {
-        navigation.navigate('Main');
-      } else {
-        Alert.alert('Login failed');
-      }
-    } catch (e) {
-      Alert.alert('Network error');
+      await loginRequest(username, password);
+      navigation.navigate('Main');
+    } catch {
+      Alert.alert('Login failed');
     }
   };
 

--- a/ios-app/screens/MapScreen.js
+++ b/ios-app/screens/MapScreen.js
@@ -1,12 +1,24 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import MapView, { Marker } from 'react-native-maps';
+import { fetchDetections } from '../services/api';
 
 export default function MapScreen() {
-  const markers = [
-    { id: 1, title: 'Fox', coordinate: { latitude: 37.78825, longitude: -122.4324 } },
-    { id: 2, title: 'Deer', coordinate: { latitude: 37.78925, longitude: -122.4344 } },
-  ];
+  const [markers, setMarkers] = useState([]);
+
+  useEffect(() => {
+    fetchDetections()
+      .then((list) =>
+        setMarkers(
+          list.map((d) => ({
+            id: d.id,
+            title: d.species,
+            coordinate: { latitude: d.latitude, longitude: d.longitude },
+          }))
+        )
+      )
+      .catch(() => {});
+  }, []);
 
   return (
     <View style={styles.container}>

--- a/ios-app/screens/RegisterScreen.js
+++ b/ios-app/screens/RegisterScreen.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { View, TextInput, Button, StyleSheet, Alert } from 'react-native';
-
-const BASE_URL = 'http://localhost:8000';
+import { register as registerRequest } from '../services/api';
 
 export default function RegisterScreen({ navigation }) {
   const [username, setUsername] = useState('');
@@ -14,22 +13,11 @@ export default function RegisterScreen({ navigation }) {
       return;
     }
     try {
-      const resp = await fetch(`${BASE_URL}/register`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: `username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
-        credentials: 'include',
-      });
-      if (resp.ok) {
-        Alert.alert('Registration complete');
-        navigation.navigate('Login');
-      } else {
-        Alert.alert('Registration failed');
-      }
-    } catch (e) {
-      Alert.alert('Network error');
+      await registerRequest(username, password);
+      Alert.alert('Registration complete');
+      navigation.navigate('Login');
+    } catch {
+      Alert.alert('Registration failed');
     }
   };
 

--- a/ios-app/services/api.js
+++ b/ios-app/services/api.js
@@ -1,0 +1,39 @@
+export const BASE_URL = 'http://localhost:8000';
+
+export async function login(username, password) {
+  const resp = await fetch(`${BASE_URL}/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: `username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
+    credentials: 'include',
+  });
+  if (!resp.ok) {
+    throw new Error('Login failed');
+  }
+}
+
+export async function register(username, password) {
+  const resp = await fetch(`${BASE_URL}/register`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: `username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
+    credentials: 'include',
+  });
+  if (!resp.ok) {
+    throw new Error('Registration failed');
+  }
+}
+
+export async function fetchDetections() {
+  const resp = await fetch(`${BASE_URL}/api/detections`, {
+    credentials: 'include',
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to fetch detections');
+  }
+  return resp.json();
+}


### PR DESCRIPTION
## Summary
- integrate detection fetching into Map and List screens
- centralize REST calls in `services/api.js`
- use API service in login and registration screens
- update task list to mark service integration as done

## Testing
- `npm test --silent` *(fails: no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_685d4ddc92688333b71a8b6ade48d787