### PR TITLE
Add push notifications for iOS app

### DIFF
--- a/ios-app/AppContext.js
+++ b/ios-app/AppContext.js
@@ -1,5 +1,10 @@
 import React, { createContext, useState, useEffect } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  registerForPushNotificationsAsync,
+  checkForNewDetections,
+} from './services/notifications';
+import { fetchDetections } from './services/api';
 
 const PREFS_KEY = 'settings';
 
@@ -34,6 +39,26 @@ export function AppProvider({ children }) {
     const prefs = { darkMode, notifications };
     AsyncStorage.setItem(PREFS_KEY, JSON.stringify(prefs)).catch(() => {});
   }, [darkMode, notifications]);
+
+  useEffect(() => {
+    let timer;
+    async function poll() {
+      try {
+        const list = await fetchDetections();
+        checkForNewDetections(list);
+      } catch {
+        // ignore errors
+      }
+    }
+    if (notifications) {
+      registerForPushNotificationsAsync().catch(() => {});
+      poll();
+      timer = setInterval(poll, 60000);
+    }
+    return () => {
+      if (timer) clearInterval(timer);
+    };
+  }, [notifications]);
 
   return (
     <AppContext.Provider value={{ darkMode, notifications, setDarkMode, setNotifications }}>

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -15,6 +15,7 @@ cd ios-app
 npm install
 npx expo install react-native-maps
 npx expo install @react-native-async-storage/async-storage
+npx expo install expo-notifications expo-device
 npx expo start
 ```
 After the Metro bundler starts, scan the QR code in your terminal with the Expo Go app to launch NightScan on your device.

--- a/ios-app/TASKS.md
+++ b/ios-app/TASKS.md
@@ -3,7 +3,7 @@
 - [x] Integrate API service for fetching detections
 - [x] Manage global app state with React context
 - [x] Implement login and registration screens
-- [ ] Add push notifications for new detections
+- [x] Add push notifications for new detections
 - [ ] Provide offline caching of the detection list
 - [ ] Write basic unit tests for components
 - [x] Implement a detection detail screen with map and photo

--- a/ios-app/package.json
+++ b/ios-app/package.json
@@ -17,7 +17,9 @@
     "react-native-maps": "^1.6.0",
     "expo": "^53.0.12",
     "expo-status-bar": "^2.2.3",
-    "@react-native-async-storage/async-storage": "^1.23.0"
+    "@react-native-async-storage/async-storage": "^1.23.0",
+    "expo-notifications": "^0.31.3",
+    "expo-device": "^5.6.2"
   },
   "devDependencies": {
     "expo-cli": "^6.3.10"

--- a/ios-app/services/notifications.js
+++ b/ios-app/services/notifications.js
@@ -1,0 +1,47 @@
+import * as Notifications from 'expo-notifications';
+import * as Device from 'expo-device';
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: false,
+    shouldSetBadge: false,
+  }),
+});
+
+export async function registerForPushNotificationsAsync() {
+  if (!Device.isDevice) {
+    return false;
+  }
+  const { status: existingStatus } = await Notifications.getPermissionsAsync();
+  let finalStatus = existingStatus;
+  if (existingStatus !== 'granted') {
+    const { status } = await Notifications.requestPermissionsAsync();
+    finalStatus = status;
+  }
+  return finalStatus === 'granted';
+}
+
+export function sendDetectionNotification(detection) {
+  return Notifications.scheduleNotificationAsync({
+    content: {
+      title: 'New detection',
+      body: detection.species,
+    },
+    trigger: null,
+  });
+}
+
+let lastDetectionId = 0;
+
+export function checkForNewDetections(detections) {
+  const maxId = detections.reduce((acc, d) => Math.max(acc, d.id), 0);
+  if (lastDetectionId && maxId > lastDetectionId) {
+    detections
+      .filter((d) => d.id > lastDetectionId)
+      .forEach((d) => {
+        sendDetectionNotification(d).catch(() => {});
+      });
+  }
+  lastDetectionId = maxId;
+}


### PR DESCRIPTION
## Summary
- implement push notification helpers
- poll for detections when notifications are enabled
- document new expo-notifications dependency
- update task list for iOS app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e3cc0a55483339bdfc7558d5b15b9