### PR TITLE
Configure Jest for React Native tests

### DIFF
--- a/ios-app/TASKS.md
+++ b/ios-app/TASKS.md
@@ -10,4 +10,4 @@
 - [x] Add search and filtering for the detection list
 - [x] Create a settings screen and persist preferences
 - [x] Support dark mode theming across the app
-- [ ] Configure Jest with React Native Testing Library
+- [x] Configure Jest with React Native Testing Library

--- a/ios-app/jest.setup.js
+++ b/ios-app/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-native/extend-expect';

--- a/ios-app/package.json
+++ b/ios-app/package.json
@@ -33,7 +33,7 @@
   "jest": {
     "preset": "react-native",
     "setupFilesAfterEnv": [
-      "@testing-library/jest-native/extend-expect"
+      "<rootDir>/jest.setup.js"
     ],
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|@react-native|@react-navigation))"


### PR DESCRIPTION
## Summary
- configure Jest for the React Native app
- create a small Jest setup file
- mark configuration task complete in TASKS

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e45b01da483339b12f92ead805143