### PR TITLE
Add zone filtering on iOS list and map

### DIFF
--- a/ios-app/AppContext.js
+++ b/ios-app/AppContext.js
@@ -11,13 +11,16 @@ const PREFS_KEY = 'settings';
 export const AppContext = createContext({
   darkMode: false,
   notifications: false,
+  zoneFilter: '',
   setDarkMode: () => {},
   setNotifications: () => {},
+  setZoneFilter: () => {},
 });
 
 export function AppProvider({ children }) {
   const [darkMode, setDarkMode] = useState(false);
   const [notifications, setNotifications] = useState(false);
+  const [zoneFilter, setZoneFilter] = useState('');
 
   useEffect(() => {
     async function load() {
@@ -27,6 +30,7 @@ export function AppProvider({ children }) {
           const prefs = JSON.parse(raw);
           setDarkMode(!!prefs.darkMode);
           setNotifications(!!prefs.notifications);
+          if (prefs.zoneFilter) setZoneFilter(prefs.zoneFilter);
         }
       } catch {
         // ignore read errors
@@ -36,9 +40,9 @@ export function AppProvider({ children }) {
   }, []);
 
   useEffect(() => {
-    const prefs = { darkMode, notifications };
+    const prefs = { darkMode, notifications, zoneFilter };
     AsyncStorage.setItem(PREFS_KEY, JSON.stringify(prefs)).catch(() => {});
-  }, [darkMode, notifications]);
+  }, [darkMode, notifications, zoneFilter]);
 
   useEffect(() => {
     let timer;
@@ -61,7 +65,16 @@ export function AppProvider({ children }) {
   }, [notifications]);
 
   return (
-    <AppContext.Provider value={{ darkMode, notifications, setDarkMode, setNotifications }}>
+    <AppContext.Provider
+      value={{
+        darkMode,
+        notifications,
+        zoneFilter,
+        setDarkMode,
+        setNotifications,
+        setZoneFilter,
+      }}
+    >
       {children}
     </AppContext.Provider>
   );

--- a/ios-app/TASKS.md
+++ b/ios-app/TASKS.md
@@ -13,5 +13,5 @@
 - [x] Configure Jest with React Native Testing Library
 
 - [x] Implement scanning feature to upload media files using FormData and PREDICT_API_URL
-- [ ] Add geographic filtering by zone on list and map
+- [x] Add geographic filtering by zone on list and map
 - [ ] Enable sharing and export of detections (CSV or KMZ)

--- a/ios-app/__tests__/DetectionListScreen.test.js
+++ b/ios-app/__tests__/DetectionListScreen.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import DetectionListScreen from '../screens/DetectionListScreen';
+import * as api from '../services/api';
+import { AppContext } from '../AppContext';
+
+jest.mock('../services/api');
+
+function Wrapper({ children }) {
+  const [zoneFilter, setZoneFilter] = React.useState('');
+  return (
+    <AppContext.Provider
+      value={{
+        darkMode: false,
+        notifications: false,
+        zoneFilter,
+        setDarkMode: jest.fn(),
+        setNotifications: jest.fn(),
+        setZoneFilter,
+      }}
+    >
+      {children}
+    </AppContext.Provider>
+  );
+}
+
+test('filters detection list by zone', async () => {
+  api.fetchDetections.mockResolvedValue([
+    { id: 1, species: 'Bat A', time: 't1', zone: 'East' },
+    { id: 2, species: 'Bat B', time: 't2', zone: 'West' },
+  ]);
+  const navigation = { navigate: jest.fn() };
+  const { getByPlaceholderText, queryByText } = render(
+    <DetectionListScreen navigation={navigation} />,
+    { wrapper: Wrapper }
+  );
+  await waitFor(() => expect(api.fetchDetections).toHaveBeenCalled());
+  fireEvent.changeText(getByPlaceholderText('Filter by zone'), 'West');
+  await waitFor(() => {
+    expect(queryByText('Bat B')).toBeTruthy();
+    expect(queryByText('Bat A')).toBeNull();
+  });
+});

--- a/ios-app/__tests__/MapScreen.test.js
+++ b/ios-app/__tests__/MapScreen.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, waitFor } from '@testing-library/react-native';
 import MapScreen from '../screens/MapScreen';
 import * as api from '../services/api';
+import { AppContext } from '../AppContext';
 
 jest.mock('../services/api');
 jest.mock('react-native-maps', () => {
@@ -18,13 +19,56 @@ jest.mock('react-native-maps', () => {
 
 test('renders markers from API', async () => {
   api.fetchDetections.mockResolvedValue([
-    { id: 1, species: 'Bat A', latitude: 1, longitude: 2 },
-    { id: 2, species: 'Bat B', latitude: 3, longitude: 4 },
+    { id: 1, species: 'Bat A', latitude: 1, longitude: 2, zone: 'East' },
+    { id: 2, species: 'Bat B', latitude: 3, longitude: 4, zone: 'West' },
   ]);
-  const { queryByTestId } = render(<MapScreen />);
+  const Wrapper = ({ children }) => (
+    <AppContext.Provider
+      value={{
+        darkMode: false,
+        notifications: false,
+        zoneFilter: '',
+        setDarkMode: jest.fn(),
+        setNotifications: jest.fn(),
+        setZoneFilter: jest.fn(),
+      }}
+    >
+      {children}
+    </AppContext.Provider>
+  );
+  const { queryByTestId } = render(<MapScreen />, { wrapper: Wrapper });
   await waitFor(() => {
     expect(api.fetchDetections).toHaveBeenCalled();
     expect(queryByTestId('marker-1')).toBeTruthy();
     expect(queryByTestId('marker-2')).toBeTruthy();
+  });
+});
+
+test('filters markers by zone', async () => {
+  api.fetchDetections.mockResolvedValue([
+    { id: 1, species: 'Bat A', latitude: 1, longitude: 2, zone: 'East' },
+    { id: 2, species: 'Bat B', latitude: 3, longitude: 4, zone: 'West' },
+  ]);
+  const Wrapper = ({ children }) => {
+    const [zoneFilter, setZoneFilter] = React.useState('East');
+    return (
+      <AppContext.Provider
+        value={{
+          darkMode: false,
+          notifications: false,
+          zoneFilter,
+          setDarkMode: jest.fn(),
+          setNotifications: jest.fn(),
+          setZoneFilter,
+        }}
+      >
+        {children}
+      </AppContext.Provider>
+    );
+  };
+  const { queryByTestId } = render(<MapScreen />, { wrapper: Wrapper });
+  await waitFor(() => {
+    expect(queryByTestId('marker-1')).toBeTruthy();
+    expect(queryByTestId('marker-2')).toBeNull();
   });
 });

--- a/ios-app/jest.setup.js
+++ b/ios-app/jest.setup.js
@@ -1,1 +1,16 @@
 import '@testing-library/jest-native/extend-expect';
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+jest.mock('expo-notifications', () => ({
+  __esModule: true,
+  default: {},
+  addNotificationReceivedListener: jest.fn(),
+  getPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
+  requestPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
+  setNotificationHandler: jest.fn(),
+  scheduleNotificationAsync: jest.fn(),
+}));
+jest.mock('expo-device', () => ({
+  isDevice: true,
+}));

--- a/ios-app/screens/DetectionListScreen.js
+++ b/ios-app/screens/DetectionListScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import {
   View,
   Text,
@@ -9,8 +9,10 @@ import {
 } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { fetchDetections } from '../services/api';
+import { AppContext } from '../AppContext';
 
 export default function DetectionListScreen({ navigation }) {
+  const { zoneFilter, setZoneFilter } = useContext(AppContext);
   const [detections, setDetections] = useState([]);
   const [query, setQuery] = useState('');
   const [refreshing, setRefreshing] = useState(false);
@@ -45,8 +47,10 @@ export default function DetectionListScreen({ navigation }) {
     }
   }
 
-  const filtered = detections.filter((d) =>
-    d.species.toLowerCase().includes(query.toLowerCase())
+  const filtered = detections.filter(
+    (d) =>
+      d.species.toLowerCase().includes(query.toLowerCase()) &&
+      (!zoneFilter || (d.zone || '').toLowerCase().includes(zoneFilter.toLowerCase()))
   );
 
   const renderItem = ({ item }) => (
@@ -67,6 +71,12 @@ export default function DetectionListScreen({ navigation }) {
         placeholder="Search species"
         value={query}
         onChangeText={setQuery}
+      />
+      <TextInput
+        style={styles.search}
+        placeholder="Filter by zone"
+        value={zoneFilter}
+        onChangeText={setZoneFilter}
       />
       <FlatList
         style={styles.list}

--- a/ios-app/screens/MapScreen.js
+++ b/ios-app/screens/MapScreen.js
@@ -1,17 +1,20 @@
-import React, { useEffect, useState } from 'react';
-import { View, StyleSheet } from 'react-native';
+import React, { useEffect, useState, useContext } from 'react';
+import { View, StyleSheet, TextInput } from 'react-native';
 import MapView, { Marker } from 'react-native-maps';
 import { fetchDetections } from '../services/api';
+import { AppContext } from '../AppContext';
 
 export default function MapScreen() {
-  const [markers, setMarkers] = useState([]);
+  const { zoneFilter, setZoneFilter } = useContext(AppContext);
+  const [allMarkers, setAllMarkers] = useState([]);
 
   useEffect(() => {
     fetchDetections()
       .then((list) =>
-        setMarkers(
+        setAllMarkers(
           list.map((d) => ({
             id: d.id,
+            zone: d.zone,
             title: d.species,
             coordinate: { latitude: d.latitude, longitude: d.longitude },
           }))
@@ -20,8 +23,18 @@ export default function MapScreen() {
       .catch(() => {});
   }, []);
 
+  const markers = allMarkers.filter((m) =>
+    !zoneFilter || (m.zone || '').toLowerCase().includes(zoneFilter.toLowerCase())
+  );
+
   return (
     <View style={styles.container}>
+      <TextInput
+        style={styles.filter}
+        placeholder="Filter by zone"
+        value={zoneFilter}
+        onChangeText={setZoneFilter}
+      />
       <MapView
         style={styles.map}
         initialRegion={{
@@ -47,6 +60,16 @@ export default function MapScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  filter: {
+    position: 'absolute',
+    top: 10,
+    left: 10,
+    right: 10,
+    backgroundColor: '#fff',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    zIndex: 1,
   },
   map: {
     ...StyleSheet.absoluteFillObject,


### PR DESCRIPTION
## Summary
- enable storing `zoneFilter` in `AppContext`
- filter detection list and map markers by zone
- mock AsyncStorage and Expo libs for Jest
- test zone filtering behaviour
- mark task as complete

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e509c37148333aeae7fe77a40c4b7