### PR TITLE
Improve energy scheduling

### DIFF
--- a/NightScanPi/Program/utils/energy_manager.py
+++ b/NightScanPi/Program/utils/energy_manager.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 from datetime import datetime
+import os
 import subprocess
 
 
-START_HOUR = 18
-STOP_HOUR = 10
+# Active hours can be customized through environment variables
+START_HOUR = int(os.getenv("NIGHTSCAN_START_HOUR", "18"))
+STOP_HOUR = int(os.getenv("NIGHTSCAN_STOP_HOUR", "10"))
 
 
 def within_active_period(now: datetime | None = None) -> bool:

--- a/NightScanPi/README.md
+++ b/NightScanPi/README.md
@@ -102,6 +102,10 @@ TPL5110 coupe automatiquement le courant en dehors de la plage horaire utile
 
 Le Pi est alimenté uniquement de 18h à 10h
 
+Les horaires peuvent être adaptés en définissant les variables
+`NIGHTSCAN_START_HOUR` et `NIGHTSCAN_STOP_HOUR` avant l'exécution des scripts
+(`energy_manager.py`, `main.py`, etc.).
+
 Le traitement des fichiers audio (.wav → .npy) se fait après 12h, pour éviter les pics de charge pendant la collecte
 
 ## Aperçu du dépôt NightScan

--- a/tests/test_energy_manager.py
+++ b/tests/test_energy_manager.py
@@ -1,0 +1,51 @@
+import sys
+import importlib
+from pathlib import Path
+from datetime import datetime
+import os
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+MODULE_PATH = 'NightScanPi.Program.utils.energy_manager'
+
+
+def reload_energy_manager(start=None, stop=None):
+    if start is not None:
+        os.environ['NIGHTSCAN_START_HOUR'] = str(start)
+    else:
+        os.environ.pop('NIGHTSCAN_START_HOUR', None)
+    if stop is not None:
+        os.environ['NIGHTSCAN_STOP_HOUR'] = str(stop)
+    else:
+        os.environ.pop('NIGHTSCAN_STOP_HOUR', None)
+    if MODULE_PATH in sys.modules:
+        del sys.modules[MODULE_PATH]
+    return importlib.import_module(MODULE_PATH)
+
+
+def test_within_active_period_defaults(monkeypatch):
+    mod = reload_energy_manager()
+    t_active = datetime(2022, 1, 1, 19, 0, 0)
+    t_inactive = datetime(2022, 1, 1, 11, 0, 0)
+    assert mod.START_HOUR == 18
+    assert mod.STOP_HOUR == 10
+    assert mod.within_active_period(t_active)
+    assert not mod.within_active_period(t_inactive)
+
+
+def test_custom_hours(monkeypatch):
+    mod = reload_energy_manager(start=6, stop=18)
+    t_active = datetime(2022, 1, 1, 7, 0, 0)
+    t_inactive = datetime(2022, 1, 1, 19, 0, 0)
+    assert mod.START_HOUR == 6
+    assert mod.STOP_HOUR == 18
+    assert mod.within_active_period(t_active)
+    assert not mod.within_active_period(t_inactive)
+
+
+def test_cross_midnight(monkeypatch):
+    mod = reload_energy_manager(start=20, stop=5)
+    assert mod.within_active_period(datetime(2022, 1, 1, 21, 0, 0))
+    assert mod.within_active_period(datetime(2022, 1, 1, 4, 0, 0))
+    assert not mod.within_active_period(datetime(2022, 1, 1, 12, 0, 0))
+


### PR DESCRIPTION
## Summary
- allow configuring active hours in `energy_manager.py`
- document `NIGHTSCAN_START_HOUR` and `NIGHTSCAN_STOP_HOUR` in NightScanPi README
- test the energy manager utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f1b6760a483338ecc36274ff5625f