### PR TITLE
Add Wi-Fi credentials helper

### DIFF
--- a/NightScanPi/Program/wifi_config.py
+++ b/NightScanPi/Program/wifi_config.py
@@ -28,16 +28,30 @@ def save_credentials(ssid: str, password: str, out_file: Path) -> None:
     out_file.write_text(json.dumps({"ssid": ssid, "password": password}))
 
 
+def apply_credentials_file(file_path: Path, path: Path | None = None) -> None:
+    """Read JSON credentials from ``file_path`` and write the config."""
+    if path is None:
+        path = CONFIG_PATH
+    data = json.loads(Path(file_path).read_text())
+    write_wifi_config(data["ssid"], data["password"], path)
+
+
 if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("ssid")
-    parser.add_argument("password")
+    parser.add_argument("ssid", nargs="?")
+    parser.add_argument("password", nargs="?")
     parser.add_argument("--out", type=Path, help="Store credentials instead of writing to system")
+    parser.add_argument("--apply", type=Path, help="Apply credentials from JSON file")
     args = parser.parse_args()
 
-    if args.out:
-        save_credentials(args.ssid, args.password, args.out)
+    if args.apply:
+        apply_credentials_file(args.apply, args.out or CONFIG_PATH)
+    elif args.ssid and args.password:
+        if args.out:
+            save_credentials(args.ssid, args.password, args.out)
+        else:
+            write_wifi_config(args.ssid, args.password)
     else:
-        write_wifi_config(args.ssid, args.password)
+        parser.error("SSID and password required unless --apply is used")

--- a/tests/test_energy_manager.py
+++ b/tests/test_energy_manager.py
@@ -69,4 +69,3 @@ def test_schedule_shutdown(monkeypatch):
     monkeypatch.setattr(mod.subprocess, "run", fake_run)
     mod.schedule_shutdown(datetime(2022, 1, 1, 9, 0, 0))
     assert run_args == [["sudo", "shutdown", "-h", "10:00"]]
-

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -27,7 +27,9 @@ def test_create_app_requires_database_uri(monkeypatch):
 
 def test_index_rejects_bad_mimetype(monkeypatch, tmp_path):
     monkeypatch.setenv("SECRET_KEY", "test")
-    monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", f"sqlite:///{tmp_path/'db.sqlite'}")
+    monkeypatch.setenv(
+        "SQLALCHEMY_DATABASE_URI", f"sqlite:///{tmp_path / 'db.sqlite'}"
+    )
     module = load_app_module()
     app = module.create_app()
     app.config["WTF_CSRF_ENABLED"] = False
@@ -47,6 +49,7 @@ def test_index_rejects_bad_mimetype(monkeypatch, tmp_path):
     def fake_post(*args, **kwargs):
         nonlocal called
         called = True
+
         class Dummy:
             def raise_for_status(self):
                 pass
@@ -68,7 +71,9 @@ def test_index_rejects_bad_mimetype(monkeypatch, tmp_path):
 
 def test_register_password_validation(monkeypatch, tmp_path):
     monkeypatch.setenv("SECRET_KEY", "test")
-    monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", f"sqlite:///{tmp_path/'db.sqlite'}")
+    monkeypatch.setenv(
+        "SQLALCHEMY_DATABASE_URI", f"sqlite:///{tmp_path / 'db.sqlite'}"
+    )
     module = load_app_module()
     app = module.create_app()
     app.config["WTF_CSRF_ENABLED"] = False
@@ -83,7 +88,9 @@ def test_register_password_validation(monkeypatch, tmp_path):
 
 def test_login_rate_limiting(monkeypatch, tmp_path):
     monkeypatch.setenv("SECRET_KEY", "test")
-    monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", f"sqlite:///{tmp_path/'db.sqlite'}")
+    monkeypatch.setenv(
+        "SQLALCHEMY_DATABASE_URI", f"sqlite:///{tmp_path / 'db.sqlite'}"
+    )
     module = load_app_module()
     app = module.create_app()
     app.config["WTF_CSRF_ENABLED"] = False

--- a/tests/test_wifi_config.py
+++ b/tests/test_wifi_config.py
@@ -1,0 +1,19 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from NightScanPi.Program import wifi_config
+
+
+def test_apply_credentials_file(tmp_path, monkeypatch):
+    cred = {"ssid": "Net", "password": "pass"}
+    cred_file = tmp_path / "cred.json"
+    cred_file.write_text(json.dumps(cred))
+    out_conf = tmp_path / "wpa.conf"
+    monkeypatch.setattr(wifi_config, "CONFIG_PATH", out_conf)
+    wifi_config.apply_credentials_file(cred_file)
+    text = out_conf.read_text()
+    assert "ssid=\"Net\"" in text
+    assert "psk=\"pass\"" in text


### PR DESCRIPTION
## Summary
- add `apply_credentials_file` function to write Wi-Fi config from JSON
- extend CLI options in `wifi_config.py`
- clean up test files for flake8
- test new Wi-Fi helper

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ff25760908333bbd17188d2ee4e76