### PR TITLE
Align NightScanPi audio processing with predict script

### DIFF
--- a/NightScanPi/Program/audio_capture.py
+++ b/NightScanPi/Program/audio_capture.py
@@ -10,7 +10,7 @@ import pyaudio
 CHUNK = 1024
 FORMAT = pyaudio.paInt16
 CHANNELS = 1
-RATE = 44100
+RATE = 22050
 
 
 def record_segment(duration: int, out_path: Path) -> None:

--- a/NightScanPi/README.md
+++ b/NightScanPi/README.md
@@ -57,6 +57,9 @@ a chaque détection audio quand ça dépasse un seuil, il capture:
 🕛 À partir de 12h :
 
 Les fichiers audio sont transformés en spectrogrammes .npy
+Les enregistrements sont rééchantillonnés à 22 050 Hz et convertis en
+mel-spectrogrammes exprimés en dB afin de correspondre au traitement de
+`predict.py`
 
 Les fichiers .wav sont automatiquement supprimés si la carte SD dépasse 70% de remplissage
 

--- a/tests/test_spectrogram_gen.py
+++ b/tests/test_spectrogram_gen.py
@@ -10,7 +10,7 @@ import NightScanPi.Program.spectrogram_gen as sg
 def test_scheduled_conversion_skips_before_noon(tmp_path, monkeypatch):
     called = False
 
-    def fake_convert(wav_dir, spec_dir, remove=False):
+    def fake_convert(wav_dir, spec_dir, remove=False, *, sr=22050):
         nonlocal called
         called = True
 
@@ -31,7 +31,7 @@ def test_scheduled_conversion_skips_before_noon(tmp_path, monkeypatch):
 def test_scheduled_conversion_deletes_when_threshold(tmp_path, monkeypatch):
     called = False
 
-    def fake_convert(wav_dir, spec_dir, remove=False):
+    def fake_convert(wav_dir, spec_dir, remove=False, *, sr=22050):
         nonlocal called
         called = True
 


### PR DESCRIPTION
## Summary
- use 22050 Hz sample rate when recording audio
- convert WAV files to mel-spectrograms with resampling and AmplitudeToDB
- mention resampling and dB conversion in NightScanPi docs
- adapt unit tests for new spectrogram conversion parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68600de347ac8333a1f54d98b274da6b