### PR TITLE
Add unit tests for Pi scripts

### DIFF
--- a/NightScanPi/Program/audio_capture.py
+++ b/NightScanPi/Program/audio_capture.py
@@ -29,7 +29,7 @@ def record_segment(duration: int, out_path: Path) -> None:
     p.terminate()
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    with wave.open(out_path, "wb") as wf:
+    with wave.open(str(out_path), "wb") as wf:
         wf.setnchannels(CHANNELS)
         wf.setsampwidth(p.get_sample_size(FORMAT))
         wf.setframerate(RATE)

--- a/TODO_NightScanPi.md
+++ b/TODO_NightScanPi.md
@@ -30,5 +30,5 @@ Cette liste pourra être complétée au fur et à mesure de l'avancement du proj
 - [ ] Créer un service pour recevoir les identifiants Wi-Fi depuis l'application mobile et appliquer `wifi_config.py`.
 - [ ] Ajouter la prise en charge du module SIM pour le transfert des données lorsque le Wi-Fi est indisponible.
 - [ ] Écrire un script d'installation automatisée pour le Raspberry Pi (packages et configuration).
-- [ ] Ajouter des tests unitaires pour `audio_capture.py` et `main.py`.
+- [x] Ajouter des tests unitaires pour `audio_capture.py` et `main.py`.
 - [ ] Fournir un exemple de fichier de configuration et activer un journal des erreurs.

--- a/tests/test_audio_capture.py
+++ b/tests/test_audio_capture.py
@@ -1,0 +1,37 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from NightScanPi.Program import audio_capture
+
+
+def test_record_segment(tmp_path, monkeypatch):
+    class DummyStream:
+        def __init__(self):
+            self.read_calls = 0
+        def read(self, chunk, exception_on_overflow=False):
+            self.read_calls += 1
+            return b"\x00" * chunk
+        def stop_stream(self):
+            pass
+        def close(self):
+            pass
+    class DummyPyAudio:
+        def __init__(self):
+            self.stream = DummyStream()
+        def open(self, format, channels, rate, input=True, frames_per_buffer=0):
+            return self.stream
+        def get_sample_size(self, fmt):
+            return 2
+        def terminate(self):
+            pass
+    dummy = types.SimpleNamespace(paInt16=1, PyAudio=lambda: DummyPyAudio())
+    monkeypatch.setattr(audio_capture, "pyaudio", dummy)
+
+    out_path = tmp_path / "test.wav"
+    audio_capture.record_segment(1, out_path)
+    assert out_path.exists()
+    assert out_path.read_bytes().startswith(b"RIFF")
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,39 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from NightScanPi.Program import main
+
+
+def test_run_cycle(tmp_path, monkeypatch):
+    audio_called = False
+    image_called = False
+
+    def fake_record_segment(duration, out_path):
+        nonlocal audio_called
+        out_path = Path(out_path)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_bytes(b"data")
+        audio_called = True
+
+    def fake_capture_image(out_dir):
+        nonlocal image_called
+        out_dir = Path(out_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out = out_dir / "image.jpg"
+        out.write_bytes(b"data")
+        image_called = True
+        return out
+
+    monkeypatch.setattr(main, "audio_capture", types.SimpleNamespace(record_segment=fake_record_segment))
+    monkeypatch.setattr(main, "camera_trigger", types.SimpleNamespace(capture_image=fake_capture_image))
+
+    main.run_cycle(tmp_path)
+
+    assert audio_called
+    assert image_called
+    assert any(p.suffix == ".wav" for p in (tmp_path / "audio").iterdir())
+    assert any(p.suffix == ".jpg" for p in (tmp_path / "images").iterdir())
+


### PR DESCRIPTION
## Summary
- add unit tests for `audio_capture.py` and `main.py`
- fix `audio_capture.record_segment` to pass string path to `wave.open`
- mark the checklist item in `TODO_NightScanPi.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860144e2780833387ed4550f369df7c