### PR TITLE
Add logging to file and config example

### DIFF
--- a/NightScanPi/Program/main.py
+++ b/NightScanPi/Program/main.py
@@ -4,13 +4,22 @@ from __future__ import annotations
 from pathlib import Path
 import time
 import logging
+import os
 
 from . import audio_capture
 from . import camera_trigger
 from .utils import energy_manager
 from .utils import detector
 
-logging.basicConfig(level=logging.INFO)
+LOG_PATH = Path(os.getenv("NIGHTSCAN_LOG", "nightscan.log"))
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[
+        logging.FileHandler(LOG_PATH),
+        logging.StreamHandler(),
+    ],
+)
 
 
 def run_cycle(base_dir: Path) -> None:

--- a/README.md
+++ b/README.md
@@ -226,3 +226,10 @@ French-speaking contributors can refer to
 [`docs/fr/application_objectifs.md`](docs/fr/application_objectifs.md)
 for the original summary in French.
 
+
+## Configuration and logging
+
+The repository provides `config_example.ini` with typical settings such as the
+log file path and active hours. Scripts under `NightScanPi/Program` write
+informational and error messages to `nightscan.log` by default. Set the
+`NIGHTSCAN_LOG` environment variable to override the log file location.

--- a/TODO_NightScanPi.md
+++ b/TODO_NightScanPi.md
@@ -31,4 +31,4 @@ Cette liste pourra être complétée au fur et à mesure de l'avancement du proj
 - [ ] Ajouter la prise en charge du module SIM pour le transfert des données lorsque le Wi-Fi est indisponible.
 - [ ] Écrire un script d'installation automatisée pour le Raspberry Pi (packages et configuration).
 - [x] Ajouter des tests unitaires pour `audio_capture.py` et `main.py`.
-- [ ] Fournir un exemple de fichier de configuration et activer un journal des erreurs.
+- [x] Fournir un exemple de fichier de configuration et activer un journal des erreurs.

--- a/config_example.ini
+++ b/config_example.ini
@@ -1,0 +1,15 @@
+# Example NightScanPi configuration
+
+[logging]
+# Path to the log file
+log_file = nightscan.log
+
+[energy]
+# Hour (24h) when the system should start capturing
+start_hour = 18
+# Hour (24h) when the system should stop capturing
+stop_hour = 10
+
+[wifi]
+# Location of the wpa_supplicant configuration written by wifi_config.py
+config_path = /etc/wpa_supplicant/wpa_supplicant.conf


### PR DESCRIPTION
## Summary
- log to `nightscan.log` via `NIGHTSCAN_LOG` env var
- document configuration and logging in README
- add example configuration file
- mark TODO item as done

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68601d1cac148333a877347355461f22