### PR TITLE
Add Nginx setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ through the reverse proxy.
 When exposing the service to the internet, terminate HTTPS at the proxy so both
 the web app and prediction API are accessed securely.
 
+For convenience the repository provides `setup_nginx.sh`, a helper script that
+installs Nginx and writes this configuration. See
+`docs/en/nginx_setup.md` for details.
+
 ## Quick prediction test
 
 After running the setup script (`bash setup_vps_infomaniak.sh`) you can

--- a/docs/en/nginx_setup.md
+++ b/docs/en/nginx_setup.md
@@ -1,0 +1,56 @@
+# Nginx Setup
+
+This document shows how to install Nginx and configure it as a reverse proxy for the NightScan web application and prediction API.
+
+## Automatic setup
+
+Run the helper script from the repository root, replacing `example.com` with your domain name:
+
+```bash
+sudo bash setup_nginx.sh example.com
+```
+
+The script installs Nginx if needed, creates `/etc/nginx/sites-available/nightscan` and enables it. The configuration forwards `/` to the Flask app on port 8000 and `/api/` to the prediction API on port 8001.
+
+After running the script, verify that the service is reachable at `http://example.com`. For production deployments you should obtain HTTPS certificates, for instance with `certbot`:
+
+```bash
+sudo apt install certbot python3-certbot-nginx
+sudo certbot --nginx -d example.com
+```
+
+This enables HTTPS for the site and redirects HTTP traffic to the secure endpoint.
+
+## Manual configuration
+
+If you prefer to configure Nginx manually, create `/etc/nginx/sites-available/nightscan` with the following contents:
+
+```nginx
+server {
+    listen 80;
+    server_name example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8001/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+Enable the site with:
+
+```bash
+sudo ln -s /etc/nginx/sites-available/nightscan /etc/nginx/sites-enabled/nightscan
+sudo nginx -t
+sudo systemctl restart nginx
+```
+
+Once configured, the proxy handles all incoming requests and forwards them to the Gunicorn workers. Remember to secure the connection with HTTPS when the service is exposed on the public internet.
+

--- a/setup_nginx.sh
+++ b/setup_nginx.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+# Install Nginx and create a basic configuration for NightScan.
+# Usage: sudo bash setup_nginx.sh example.com
+# Replace example.com with your actual domain name.
+
+if [[ "$EUID" -ne 0 ]]; then
+    if command -v sudo >/dev/null 2>&1; then
+        exec sudo "$0" "$@"
+    else
+        echo "This script must run with root privileges." >&2
+        exit 1
+    fi
+fi
+
+DOMAIN="$1"
+if [ -z "$DOMAIN" ]; then
+    echo "Usage: $0 domain-name" >&2
+    exit 1
+fi
+
+apt-get update
+apt-get install -y nginx
+
+CONFIG_PATH="/etc/nginx/sites-available/nightscan"
+cat > "$CONFIG_PATH" <<EOF2
+server {
+    listen 80;
+    server_name $DOMAIN;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8001/;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+    }
+}
+EOF2
+
+ln -sf "$CONFIG_PATH" /etc/nginx/sites-enabled/nightscan
+
+nginx -t
+systemctl restart nginx
+
+echo "Nginx is configured. Consider enabling HTTPS with certbot."


### PR DESCRIPTION
## Summary
- add setup_nginx.sh for automated Nginx install
- document proxy setup in docs/en/nginx_setup.md
- mention the helper script in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603bb1ce6c8333bb7b22ffd1109327