### PR TITLE
Enhance API robustness

### DIFF
--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -14,6 +14,8 @@ def create_test_app():
     module.__file__ = str(path)
     exec(compile(source, str(path), 'exec'), module.__dict__)
     module.load_model = lambda *a, **k: None
+    module.AudioSegment.from_file = lambda *a, **k: None
+    module.predict_file = lambda *a, **k: []
     os.environ['MODEL_PATH'] = str(path)
     os.environ['CSV_DIR'] = str(path.parent)
     return module.create_app()
@@ -25,3 +27,16 @@ def test_invalid_file(tmp_path):
     data = {"file": (io.BytesIO(b"dummy"), "test.txt")}
     resp = client.post("/api/predict", data=data, content_type="multipart/form-data")
     assert resp.status_code == 400
+    assert resp.get_json()["error"] == "WAV file required"
+
+
+def test_rate_limiting(monkeypatch):
+    monkeypatch.setenv("API_RATE_LIMIT", "2 per minute")
+    app = create_test_app()
+    client = app.test_client()
+    for _ in range(2):
+        data = {"file": (io.BytesIO(b"dummy"), "test.wav")}
+        client.post("/api/predict", data=data, content_type="multipart/form-data")
+    data = {"file": (io.BytesIO(b"dummy"), "test.wav")}
+    resp = client.post("/api/predict", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 429


### PR DESCRIPTION
## Summary
- improve error handling in `api_server.py`
- log decoding/processing failures
- apply rate limiting via Flask-Limiter
- return clearer error messages in tests
- cover rate limiting in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68604736b8908333a66ce230d5b035df