### PR TITLE
Improve WAV upload validation

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -12,6 +12,7 @@
     {{ csrf_token() }}
     <input type="file" name="file" accept="audio/wav" required>
     <p>Maximum 100 MB per file, 10 GB total for your account. WAV files only.</p>
+    <p>Remaining quota: {{ '%.2f' % (remaining_bytes / (1024 * 1024 * 1024)) }} GB</p>
     <input type="submit" value="Analyze">
   </form>
   {% else %}
@@ -29,5 +30,14 @@
     {% endfor %}
   </ul>
   {% endif %}
+  {% with messages = get_flashed_messages() %}
+  {% if messages %}
+    <ul>
+    {% for message in messages %}
+      <li>{{ message }}</li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+  {% endwith %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- validate RIFF/WAVE header on upload
- display remaining quota on the index page
- show flash messages on the front page
- add tests for header validation and quota display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686049ccaac083338d51f56c62c13d7f