### PR TITLE
Add integration tests for plugins and mobile app

### DIFF
--- a/ios-app/__tests__/Notifications.test.js
+++ b/ios-app/__tests__/Notifications.test.js
@@ -1,0 +1,13 @@
+import { checkForNewDetections } from '../services/notifications';
+import * as ExpoNotif from 'expo-notifications';
+
+ExpoNotif.scheduleNotificationAsync.mockResolvedValue();
+
+test('sends notification for new detections', () => {
+  checkForNewDetections([{ id: 1, species: 'A' }]);
+  checkForNewDetections([
+    { id: 1, species: 'A' },
+    { id: 2, species: 'B' },
+  ]);
+  expect(ExpoNotif.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+});

--- a/tests/test_plugin_syntax.py
+++ b/tests/test_plugin_syntax.py
@@ -1,0 +1,17 @@
+import subprocess
+from pathlib import Path
+
+
+def check_php_syntax(path: Path) -> bool:
+    proc = subprocess.run(['php', '-l', str(path)], capture_output=True, text=True)
+    return 'No syntax errors detected' in proc.stdout
+
+
+def test_audio_upload_plugin_syntax():
+    plugin = Path(__file__).resolve().parents[1] / 'wp-plugin' / 'audio-upload' / 'audio-upload.php'
+    assert check_php_syntax(plugin)
+
+
+def test_prediction_charts_plugin_syntax():
+    plugin = Path(__file__).resolve().parents[1] / 'wp-plugin' / 'prediction-charts' / 'prediction-charts.php'
+    assert check_php_syntax(plugin)


### PR DESCRIPTION
## Summary
- add Jest test covering push notifications logic
- add PHP syntax checks for both WordPress plugins

## Testing
- `npm test --silent` in `ios-app`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686056be612c8333aacbc6a900a7a0c2