### PR TITLE
Add script to sync predictions to WordPress

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ A small plugin located in `wp-plugin/prediction-charts` can display
 user prediction statistics inside WordPress. See
 [`docs/en/wordpress_plugin.md`](docs/en/wordpress_plugin.md) for the expected
 database structure, how to export data from the Flask app and an example
-of the `[nightscan_chart]` shortcode.
+of the `[nightscan_chart]` shortcode. The repository ships with
+`export_predictions.py` to copy predictions from the Flask database to the
+WordPress table.
 
 ## Uploading from WordPress
 

--- a/docs/en/wordpress_plugin.md
+++ b/docs/en/wordpress_plugin.md
@@ -37,12 +37,20 @@ with flask_db.cursor() as cur_src, wordpress.cursor() as cur_dest:
     wordpress.commit()
 ```
 
-Adjust the connection parameters and fields to match your exact schema. You can run this via `cron` for regular synchronization.
+Adjust the connection parameters and fields to match your exact schema. A ready to use helper named `export_predictions.py` is available at the repository root. It performs the same query and accepts MySQL connection strings via the `--flask-dsn` and `--wp-dsn` options (or the `FLASK_DB_URI` and `WORDPRESS_DB_URI` environment variables).
+
+```bash
+python export_predictions.py \
+  --flask-dsn mysql://appuser:secret@localhost/nightscan \
+  --wp-dsn mysql://wpuser:secret@localhost/wordpress
+```
+
+You can run this script from `cron` for regular synchronization.
 
 ## Automating the export
 
-To keep the `ns_predictions` table current, schedule the script from your
-crontab. Edit the user's crontab and add a line like the following:
+To keep the `ns_predictions` table current, schedule the helper script from
+your crontab. Edit the user's crontab and add a line like the following:
 
 ```cron
 */10 * * * * /usr/bin/python3 /path/to/export_predictions.py \

--- a/export_predictions.py
+++ b/export_predictions.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Copy predictions from the Flask database to WordPress."""
+
+import argparse
+import os
+from urllib.parse import urlparse
+
+import pymysql
+
+
+def parse_mysql_dsn(dsn: str) -> dict:
+    """Parse ``mysql://user:pass@host/db`` and return connection kwargs."""
+    r = urlparse(dsn)
+    if r.scheme != "mysql":
+        raise ValueError("Unsupported DSN scheme: %s" % r.scheme)
+    return {
+        "host": r.hostname or "localhost",
+        "user": r.username or "",
+        "password": r.password or "",
+        "database": r.path.lstrip("/"),
+        "port": r.port or 3306,
+        "charset": "utf8mb4",
+    }
+
+
+def export_predictions(flask_dsn: str, wp_dsn: str, table: str) -> None:
+    """Copy prediction rows from the Flask DB to the WordPress table."""
+    src = pymysql.connect(**parse_mysql_dsn(flask_dsn))
+    dest = pymysql.connect(**parse_mysql_dsn(wp_dsn))
+    with src.cursor() as cur_src, dest.cursor() as cur_dest:
+        cur_src.execute(
+            "SELECT user_id, JSON_EXTRACT(result, '$.predictions[0].label') "
+            "AS species FROM prediction"
+        )
+        for user_id, species in cur_src.fetchall():
+            cur_dest.execute(
+                f"INSERT INTO {table} (user_id, species, predicted_at) "
+                "VALUES (%s, %s, NOW())",
+                (user_id, species),
+            )
+    dest.commit()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export predictions to WordPress")
+    parser.add_argument(
+        "--flask-dsn",
+        default=os.getenv("FLASK_DB_URI"),
+        help="mysql://user:pass@host/db for the Flask app",
+    )
+    parser.add_argument(
+        "--wp-dsn",
+        default=os.getenv("WORDPRESS_DB_URI"),
+        help="mysql://user:pass@host/db for WordPress",
+    )
+    parser.add_argument(
+        "--table",
+        default=os.getenv("WP_TABLE", "wp_ns_predictions"),
+        help="WordPress table name",
+    )
+    args = parser.parse_args()
+    if not args.flask_dsn or not args.wp_dsn:
+        parser.error("Both --flask-dsn and --wp-dsn must be provided")
+    export_predictions(args.flask_dsn, args.wp_dsn, args.table)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `export_predictions.py` helper
- document how to use the new script
- mention the helper in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ef1435d4833395fb642d09374537