### PR TITLE
Add HTTPS setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ When exposing the service to the internet, terminate HTTPS at the proxy so both
 the web app and prediction API are accessed securely.
 
 For convenience the repository provides `setup_nginx.sh`, a helper script that
-installs Nginx and writes this configuration. See
-`docs/en/nginx_setup.md` for details.
+installs Nginx and writes this configuration. If you prefer an end-to-end setup
+including HTTPS certificates, use `setup_nginx_tls.sh` instead. Both helpers are
+documented in `docs/en/nginx_setup.md`.
 
 ## Quick prediction test
 

--- a/docs/en/nginx_setup.md
+++ b/docs/en/nginx_setup.md
@@ -12,14 +12,13 @@ sudo bash setup_nginx.sh example.com
 
 The script installs Nginx if needed, creates `/etc/nginx/sites-available/nightscan` and enables it. The configuration forwards `/` to the Flask app on port 8000 and `/api/` to the prediction API on port 8001.
 
-After running the script, verify that the service is reachable at `http://example.com`. For production deployments you should obtain HTTPS certificates, for instance with `certbot`:
+If you want to configure HTTPS automatically, use the helper `setup_nginx_tls.sh` script instead. It runs the steps above and invokes `certbot` to obtain a Let's Encrypt certificate:
 
 ```bash
-sudo apt install certbot python3-certbot-nginx
-sudo certbot --nginx -d example.com
+sudo bash setup_nginx_tls.sh example.com
 ```
 
-This enables HTTPS for the site and redirects HTTP traffic to the secure endpoint.
+Both scripts configure Nginx and reload it. When using `setup_nginx_tls.sh` the service is immediately reachable at `https://example.com` with HTTP traffic redirected to the secure endpoint.
 
 ## Manual configuration
 

--- a/setup_nginx_tls.sh
+++ b/setup_nginx_tls.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+# Install Nginx and obtain a Let's Encrypt certificate via certbot.
+# Usage: sudo bash setup_nginx_tls.sh example.com
+# The script writes a basic reverse proxy configuration for NightScan and
+# configures HTTPS automatically.
+
+if [[ "$EUID" -ne 0 ]]; then
+    if command -v sudo >/dev/null 2>&1; then
+        exec sudo "$0" "$@"
+    else
+        echo "This script must run with root privileges." >&2
+        exit 1
+    fi
+fi
+
+DOMAIN="$1"
+if [ -z "$DOMAIN" ]; then
+    echo "Usage: $0 domain-name" >&2
+    exit 1
+fi
+
+apt-get update
+apt-get install -y nginx certbot python3-certbot-nginx
+
+CONFIG_PATH="/etc/nginx/sites-available/nightscan"
+cat > "$CONFIG_PATH" <<EOF2
+server {
+    listen 80;
+    server_name $DOMAIN;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8001/;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+    }
+}
+EOF2
+
+ln -sf "$CONFIG_PATH" /etc/nginx/sites-enabled/nightscan
+
+nginx -t
+systemctl reload nginx
+
+certbot --nginx -d "$DOMAIN" --non-interactive --agree-tos -m admin@"$DOMAIN"
+
+echo "Nginx is configured with HTTPS for $DOMAIN." 


### PR DESCRIPTION
## Summary
- add `setup_nginx_tls.sh` to configure Nginx and Certbot
- document new script in README and nginx setup guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860f46519fc83338ca078941315385a