### PR TITLE
Improve SECRET_KEY handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ with Gunicorn rather than the built in Flask runner:
 ```bash
 source env/bin/activate
 pip install gunicorn
-export SECRET_KEY="change-me"
+export SECRET_KEY=$(python -c 'import secrets; print(secrets.token_hex(32))')
 export WTF_CSRF_SECRET_KEY="$SECRET_KEY"  # optional
 export PREDICT_API_URL="https://myserver.example/api/predict"
 gunicorn -w 4 -b 0.0.0.0:8000 web.app:application
@@ -55,8 +55,9 @@ See [`docs/en/flask_app.md`](docs/en/flask_app.md) for details on the login
 routes and database initialization.
 
 Set the `PREDICT_API_URL` environment variable to point to your
-prediction service. You must also define `SECRET_KEY` to configure the
-Flask session signing; use a random string for production.
+prediction service. If `SECRET_KEY` is not defined the web app
+generates a temporary value, but you should configure a stable random
+string in production.
 `Flask-WTF` provides CSRF protection. It will reuse `SECRET_KEY` unless you
 set a dedicated `WTF_CSRF_SECRET_KEY` variable.
 To start the prediction API, define the path to the trained model and the

--- a/docs/en/flask_app.md
+++ b/docs/en/flask_app.md
@@ -61,14 +61,14 @@ database.
 
 Before starting the Flask server, define two variables:
 
-- `SECRET_KEY`: used to sign the session. Choose a random value in production.
+- `SECRET_KEY`: used to sign the session. If unset, the application generates a temporary value at startup. Provide a persistent random key in production.
 - `PREDICT_API_URL`: URL of the API that receives the files to analyze. If not set, `web/app.py` defaults to `http://localhost:8001/api/predict`. The application accepts either scheme, but in production use an `https://` endpoint.
 
 Example (install `gunicorn` if it is not already available):
 
 ```bash
 pip install gunicorn
-export SECRET_KEY="change-me"
+export SECRET_KEY=$(python -c 'import secrets; print(secrets.token_hex(32))')
 export PREDICT_API_URL="https://myserver.example/api/predict"
 gunicorn -w 4 -b 0.0.0.0:8000 web.app:application
 ```

--- a/web/app.py
+++ b/web/app.py
@@ -3,6 +3,8 @@ import json
 import re
 import mimetypes
 import requests
+import secrets
+import logging
 
 from flask import (
     Flask,
@@ -27,12 +29,17 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from werkzeug.security import generate_password_hash, check_password_hash
 
+logger = logging.getLogger(__name__)
+
 app = Flask(__name__)
 secret_key = os.environ.get("SECRET_KEY")
 if not secret_key:
-    raise RuntimeError("SECRET_KEY environment variable not set")
+    secret_key = secrets.token_hex(32)
+    logger.warning("SECRET_KEY not set; using ephemeral value")
 app.secret_key = secret_key
-app.config["WTF_CSRF_SECRET_KEY"] = os.environ.get("WTF_CSRF_SECRET_KEY", secret_key)
+app.config["WTF_CSRF_SECRET_KEY"] = os.environ.get(
+    "WTF_CSRF_SECRET_KEY", secret_key
+)
 csrf = CSRFProtect(app)
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 


### PR DESCRIPTION
## Summary
- generate an ephemeral secret key if `SECRET_KEY` is missing
- warn when falling back to a generated value
- document how to generate a random secret for production

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyaudio')*

------
https://chatgpt.com/codex/tasks/task_e_6860f97170588333a4a18b88bcaa6098