### PR TITLE
Extend login lockout duration

### DIFF
--- a/docs/en/flask_app.md
+++ b/docs/en/flask_app.md
@@ -26,7 +26,7 @@ Access to the main page (`/`) is protected by `@login_required`: only logged‑i
 
 ### Authentication security
 
-Passwords must be at least **10 characters** and contain a lowercase letter, uppercase letter, digit and symbol. Login requests are rate limited to **5 per minute** and a temporary lockout is triggered after five failed attempts from the same IP address within 15 minutes.
+Passwords must be at least **10 characters** and contain a lowercase letter, uppercase letter, digit and symbol. Login requests are rate limited to **5 per minute** and a temporary lockout is triggered after five failed attempts from the same IP address within 30 minutes.
 
 For public deployments you may instead send files from a WordPress site using
 the upload plugin described in `docs/en/wordpress_plugin.md`. The built‑in form

--- a/web/app.py
+++ b/web/app.py
@@ -60,7 +60,7 @@ limiter = Limiter(app=app, key_func=get_remote_address)
 # Track failed login attempts per IP
 FAILED_LOGINS = {}
 LOCKOUT_THRESHOLD = 5
-LOCKOUT_WINDOW = 15 * 60  # 15 minutes
+LOCKOUT_WINDOW = 30 * 60  # 30 minutes
 
 # Require at least 10 characters, including upper/lowercase, digit and symbol
 PASSWORD_RE = re.compile(r"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).{10,}$")


### PR DESCRIPTION
## Summary
- extend the Flask app lockout duration to 30 minutes
- document the new 30 minute lockout window

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861014ba86c83339100c5947565fb9a