### PR TITLE
Add simple CAPTCHA to login form

### DIFF
--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -42,7 +42,12 @@ def test_index_rejects_bad_mimetype(monkeypatch, tmp_path):
     client = app.test_client()
     client.environ_base["wsgi.url_scheme"] = "https"
     client.environ_base["HTTP_X_FORWARDED_PROTO"] = "https"
-    client.post("/login", data={"username": "user", "password": "pass"})
+    with client.session_transaction() as sess:
+        sess["captcha_answer"] = "2"
+    client.post(
+        "/login",
+        data={"username": "user", "password": "pass", "captcha": "2"},
+    )
 
     called = False
 
@@ -84,7 +89,12 @@ def test_index_rejects_bad_header(monkeypatch, tmp_path):
     client = app.test_client()
     client.environ_base["wsgi.url_scheme"] = "https"
     client.environ_base["HTTP_X_FORWARDED_PROTO"] = "https"
-    client.post("/login", data={"username": "user", "password": "pass"})
+    with client.session_transaction() as sess:
+        sess["captcha_answer"] = "2"
+    client.post(
+        "/login",
+        data={"username": "user", "password": "pass", "captcha": "2"},
+    )
 
     data = {"file": (io.BytesIO(b"notriffdata"), "test.wav", "audio/x-wav")}
     resp = client.post("/", data=data, content_type="multipart/form-data")
@@ -109,7 +119,12 @@ def test_index_shows_remaining_quota(monkeypatch, tmp_path):
     client = app.test_client()
     client.environ_base["wsgi.url_scheme"] = "https"
     client.environ_base["HTTP_X_FORWARDED_PROTO"] = "https"
-    client.post("/login", data={"username": "user", "password": "pass"})
+    with client.session_transaction() as sess:
+        sess["captcha_answer"] = "2"
+    client.post(
+        "/login",
+        data={"username": "user", "password": "pass", "captcha": "2"},
+    )
 
     resp = client.get("/")
     assert resp.status_code == 200
@@ -150,9 +165,54 @@ def test_login_rate_limiting(monkeypatch, tmp_path):
     client = app.test_client()
     client.environ_base["wsgi.url_scheme"] = "https"
     client.environ_base["HTTP_X_FORWARDED_PROTO"] = "https"
-
     for _ in range(5):
-        client.post("/login", data={"username": "user", "password": "wrong"})
+        with client.session_transaction() as sess:
+            sess["captcha_answer"] = "2"
+        client.post(
+            "/login",
+            data={"username": "user", "password": "wrong", "captcha": "2"},
+        )
 
-    resp = client.post("/login", data={"username": "user", "password": "wrong"})
+    with client.session_transaction() as sess:
+        sess["captcha_answer"] = "2"
+    resp = client.post(
+        "/login",
+        data={"username": "user", "password": "wrong", "captcha": "2"},
+    )
     assert resp.status_code == 429
+
+
+def test_login_requires_captcha(monkeypatch, tmp_path):
+    monkeypatch.setenv("SECRET_KEY", "test")
+    monkeypatch.setenv(
+        "SQLALCHEMY_DATABASE_URI", f"sqlite:///{tmp_path / 'db.sqlite'}"
+    )
+    module = load_app_module()
+    app = module.create_app()
+    app.config["WTF_CSRF_ENABLED"] = False
+    with app.app_context():
+        user = module.User(username="user")
+        user.set_password("pass1234")
+        module.db.session.add(user)
+        module.db.session.commit()
+
+    client = app.test_client()
+    client.environ_base["wsgi.url_scheme"] = "https"
+    client.environ_base["HTTP_X_FORWARDED_PROTO"] = "https"
+
+    with client.session_transaction() as sess:
+        sess["captcha_answer"] = "2"
+    resp = client.post(
+        "/login",
+        data={"username": "user", "password": "pass1234", "captcha": "99"},
+    )
+    assert resp.status_code == 200
+    assert b"Invalid captcha" in resp.data
+
+    with client.session_transaction() as sess:
+        sess["captcha_answer"] = "2"
+    resp = client.post(
+        "/login",
+        data={"username": "user", "password": "pass1234", "captcha": "2"},
+    )
+    assert resp.status_code == 302

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -10,6 +10,8 @@
     {{ csrf_token() }}
     <input type="text" name="username" placeholder="Username" required>
     <input type="password" name="password" placeholder="Password" required>
+    <label>{{ captcha_question }}</label>
+    <input type="text" name="captcha" placeholder="Answer" required>
     <input type="submit" value="Login">
   </form>
   <p><a href="{{ url_for('register') }}">Register</a></p>


### PR DESCRIPTION
## Summary
- generate and validate a basic math CAPTCHA
- display CAPTCHA challenge in login template
- update tests to accommodate CAPTCHA and test its validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686105dd16688333915fc0fd452cd99f