### PR TITLE
Fix inconsistent docs

### DIFF
--- a/Manual_en.md
+++ b/Manual_en.md
@@ -71,7 +71,19 @@ python Audio_Training/scripts/predict.py --model_path models/best_model.pth --cs
 
 The script splits the audio, runs the model and prints the three most probable species (e.g., cat, dog, etc.) with their scores. Use `--json` to get JSON output.
 
-## 5. Tips and troubleshooting
+## 5. Run the prediction API
+With a trained model you can start the small API server to process uploads from the web app or other clients. Inside the project folder run:
+
+```bash
+export MODEL_PATH="models/best_model.pth"
+export CSV_DIR="data/processed/csv"
+gunicorn -w 4 -b 0.0.0.0:8001 \
+  Audio_Training.scripts.api_server:application
+```
+
+By default the service listens on `0.0.0.0:8001`. Adjust the address with the `--host` and `--port` options if needed. The Flask app expects the API at `http://localhost:8001/api/predict` unless you set the `PREDICT_API_URL` environment variable.
+
+## 6. Tips and troubleshooting
 - **No sound detected?** Ensure your recording contains cries or sounds loud enough. Very quiet segments are skipped.
 - **FFMPEG error message?** Check that FFMPEG is installed and in your PATH (`ffmpeg -version` in a terminal).
 - **Using multiple cores**: the `--workers 4` option speeds up preprocessing on multi‑core machines. Adjust as needed.

--- a/README.md
+++ b/README.md
@@ -235,9 +235,10 @@ project is included under [`ios-app/`](ios-app/).
 **Usage**: familiar gestures (pinch to zoom, scrolling, pull to refresh) so the app remains intuitive on iOS and Android.
 **Simplicity first**: users quickly see when and where animals were observed without viewing the raw media.
 
-French-speaking contributors can refer to
-[`docs/fr/application_objectifs.md`](docs/fr/application_objectifs.md)
-for the original summary in French.
+For additional details see
+[`docs/en/application_objectives.md`](docs/en/application_objectives.md).
+The previous French version remains available at
+[`docs/fr/application_objectifs.md`](docs/fr/application_objectifs.md).
 
 
 ## Configuration and logging

--- a/docs/en/application_objectives.md
+++ b/docs/en/application_objectives.md
@@ -1,0 +1,21 @@
+# Application Goals and User Experience
+
+This document summarizes the main objectives of NightScan and the target user experience. Refer to it when planning features or refining the design.
+
+## Application Goals
+
+1. **Easy access to detections**
+   - Display an interactive map with every detection (audio or photo) gathered by field sensors.
+   - Provide a chronological list of the latest observations with the key information (species, time, location).
+2. **Quick review and notifications**
+   - Receive real-time alerts whenever a new detection is processed.
+   - Filter the data (by species or geographical area) to immediately show relevant results.
+3. **Sharing and export**
+   - Allow detections to be shared by e-mail or exported (CSV/KMZ) for later analysis. A **Export CSV** button on the list screen lets users share everything at once.
+
+## Target User Experience
+
+- **Audience**: wildlife photographers, amateur naturalists, researchers or anyone who wants to track nocturnal fauna.
+- **Interface**: clean design with a bottom navigation bar to access the map, detection list, filters and settings.
+- **Usage**: familiar gestures (pinch to zoom, scroll, pull to refresh) so the application remains intuitive on both iOS and Android.
+- **Simplicity first**: users quickly see when and where animals were detected without needing to open the raw media (photos or sounds).


### PR DESCRIPTION
## Summary
- translate application objectives doc to English
- add port info to user manual
- link new doc from README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68612ed98fd88333bf90b5739c239d3a