### PR TITLE
Add Celery for asynchronous prediction handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ export PREDICT_API_URL="https://myserver.example/api/predict"
 gunicorn -w 4 -b 0.0.0.0:8000 web.app:application
 ```
 
+The Flask app offloads the prediction request to a Celery worker when a
+file is uploaded. Start at least one worker alongside Gunicorn:
+
+```bash
+celery -A web.tasks worker --loglevel=info
+```
+
 The command above binds the web server to `0.0.0.0`, exposing it on every network interface. This is typical when running behind a reverse proxy or with firewall rules in place. If you prefer to keep the service private, bind to `127.0.0.1` or block the port using a firewall such as `ufw`.
 
 The application connects to a database using the URL in

--- a/docs/en/flask_app.md
+++ b/docs/en/flask_app.md
@@ -77,6 +77,12 @@ export PREDICT_API_URL="https://myserver.example/api/predict"
 gunicorn -w 4 -b 0.0.0.0:8000 web.app:application
 ```
 
+Start a Celery worker to handle the prediction requests asynchronously:
+
+```bash
+celery -A web.tasks worker --loglevel=info
+```
+
 In production you should place a reverse proxy such as Nginx in front of the
 Gunicorn workers and forward requests to port `8000`.
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -11,3 +11,4 @@ requests==2.32.4
 pydub==0.25.1
 pyserial==3.5
 pytest==8.3.5
+celery==5.3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,3 +66,4 @@ Werkzeug==3.1.3
 wheel==0.45.1
 WTForms==3.2.1
 Flask-Limiter==3.5.0
+celery==5.3.6

--- a/web/tasks.py
+++ b/web/tasks.py
@@ -1,0 +1,49 @@
+import io
+import json
+import os
+import requests
+from celery import Celery
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+celery = Celery(
+    __name__,
+    broker=os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379/0"),
+    backend=os.environ.get("CELERY_RESULT_BACKEND", "redis://localhost:6379/0"),
+)
+
+celery.conf.task_always_eager = os.environ.get("CELERY_TASK_ALWAYS_EAGER") == "1"
+
+# Lazy app creation to avoid circular import issues
+_db = SQLAlchemy()
+
+
+def create_celery_app() -> Flask:
+    from .app import create_app
+
+    app = create_app()
+    _db.init_app(app)
+    return app
+
+
+@celery.task
+def run_prediction(pred_id: int, filename: str, data: bytes, api_url: str) -> None:
+    app = create_celery_app()
+    with app.app_context():
+        try:
+            resp = requests.post(
+                api_url,
+                files={"file": (filename, io.BytesIO(data), "audio/wav")},
+                timeout=30,
+            )
+            resp.raise_for_status()
+            result = resp.json()
+        except requests.RequestException as exc:  # pragma: no cover - network errors
+            result = {"error": str(exc)}
+
+        from .app import Prediction, db  # import here to avoid circular deps
+
+        pred = db.session.get(Prediction, pred_id)
+        if pred:
+            pred.result = json.dumps(result)
+            db.session.commit()


### PR DESCRIPTION
## Summary
- include Celery in the dependency lists
- add `web/tasks.py` implementing a Celery worker
- queue uploads through Celery in the Flask app
- document running the worker in README and flask app docs

## Testing
- `pip install -r requirements-ci.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861483766608333aacc20494a2a4c75