### PR TITLE
Fix crash when no audio segments found

### DIFF
--- a/Audio_Training/scripts/api_server.py
+++ b/Audio_Training/scripts/api_server.py
@@ -112,6 +112,8 @@ def predict_file(path: Path) -> List[Dict]:
     """
     try:
         dataset = predict.AudioDataset([path])
+        if len(dataset) == 0:
+            return []
         loader = DataLoader(dataset, batch_size=1, shuffle=False)
     except Exception as exc:  # pragma: no cover - unexpected
         logger.exception("Failed to prepare dataset for %s: %s", path, exc)

--- a/Audio_Training/scripts/predict.py
+++ b/Audio_Training/scripts/predict.py
@@ -193,6 +193,8 @@ def main() -> None:
     num_classes = len(labels)
 
     dataset = AudioDataset(files)
+    if len(dataset) == 0:
+        raise SystemExit("No audio segments found")
     loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=False)
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")


### PR DESCRIPTION
## Summary
- prevent crashes by returning early if `AudioDataset` contains no segments
- exit `predict.py` with a clear message when no segments were extracted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68616d6750188333a329f36c659c273f