### PR TITLE
Implement JSON structured logging

### DIFF
--- a/Audio_Training/scripts/api_server.py
+++ b/Audio_Training/scripts/api_server.py
@@ -19,6 +19,8 @@ from typing import List, Dict, Optional
 import pathlib
 import os
 import logging
+
+from log_utils import setup_logging
 import io
 from types import SimpleNamespace
 from pydub import AudioSegment
@@ -39,6 +41,7 @@ MAX_FILE_SIZE = 100 * 1024 * 1024  # 100 MB limit for uploads
 app = Flask(__name__)
 
 logger = logging.getLogger(__name__)
+setup_logging()
 
 model: torch.nn.Module | None = None
 labels: List[str] | None = None
@@ -205,9 +208,6 @@ def main() -> None:
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8001)
     args = parser.parse_args()
-    logging.basicConfig(
-        format="%(levelname)s:%(processName)s:%(message)s", level=logging.INFO
-    )
     create_app(args.model_path, args.csv_dir).run(host=args.host, port=args.port)
 
 

--- a/README.md
+++ b/README.md
@@ -254,3 +254,7 @@ The repository provides `config_example.ini` with typical settings such as the
 log file path and active hours. Scripts under `NightScanPi/Program` write
 informational and error messages to `nightscan.log` by default. Set the
 `NIGHTSCAN_LOG` environment variable to override the log file location.
+
+Server modules also emit JSON-formatted logs to standard output. The helper
+function `log_utils.setup_logging()` configures the root logger accordingly so
+that errors on the Flask app or API server are easier to parse.

--- a/log_utils.py
+++ b/log_utils.py
@@ -1,0 +1,26 @@
+import logging
+import json
+from typing import Any
+
+
+class JSONFormatter(logging.Formatter):
+    """Simple JSON log formatter."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_record: dict[str, Any] = {
+            "time": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            log_record["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(log_record)
+
+
+def setup_logging(level: int = logging.INFO, stream=None) -> None:
+    """Configure root logger to emit JSON formatted logs."""
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(JSONFormatter())
+    logging.basicConfig(level=level, handlers=[handler], force=True)
+

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -1,0 +1,19 @@
+import json
+from io import StringIO
+import logging
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from log_utils import setup_logging
+
+
+def test_setup_logging_emits_json():
+    stream = StringIO()
+    setup_logging(stream=stream)
+    logger = logging.getLogger("test")
+    logger.error("failure")
+    data = json.loads(stream.getvalue())
+    assert data["message"] == "failure"
+    assert data["level"] == "ERROR"

--- a/web/app.py
+++ b/web/app.py
@@ -1,12 +1,13 @@
 import os
-import json
 import re
 import time
 import mimetypes
-import requests
 import secrets
 import logging
 import random
+import requests
+
+from log_utils import setup_logging
 
 from flask import (
     Flask,
@@ -33,6 +34,7 @@ from flask_limiter.util import get_remote_address
 from werkzeug.security import generate_password_hash, check_password_hash
 
 logger = logging.getLogger(__name__)
+setup_logging()
 
 app = Flask(__name__)
 secret_key = os.environ.get("SECRET_KEY")


### PR DESCRIPTION
## Summary
- add `log_utils` with JSON formatter and setup helper
- configure Flask app and prediction API to use structured logs
- document structured logging in README
- add unit test for `setup_logging`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68616f4bd86c8333a2cfda7b471f3ab2