### PR TITLE
Refactor API server to avoid globals

### DIFF
--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -13,7 +13,7 @@ def create_test_app():
     module = types.ModuleType('api_server_test')
     module.__file__ = str(path)
     exec(compile(source, str(path), 'exec'), module.__dict__)
-    module.load_model = lambda *a, **k: None
+    module.load_model = lambda *a, **k: (None, [], None)
     module.AudioSegment.from_file = lambda *a, **k: None
     module.predict_file = lambda *a, **k: []
     os.environ['MODEL_PATH'] = str(path)


### PR DESCRIPTION
## Summary
- eliminate global `model` and `labels` in the audio API server
- keep prediction resources in the Flask app config
- adjust tests for the new interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686181d71db08333b44ca9889e4f5389