### PR TITLE
Add time_config script

### DIFF
--- a/NightScanPi/Program/time_config.py
+++ b/NightScanPi/Program/time_config.py
@@ -1,0 +1,56 @@
+"""Initial time and timezone setup for NightScanPi."""
+from __future__ import annotations
+
+import argparse
+import subprocess
+
+try:  # pragma: no cover - optional dependency
+    from timezonefinder import TimezoneFinder
+except Exception:  # pragma: no cover - not installed
+    TimezoneFinder = None
+
+DEFAULT_LAT = 46.9480
+DEFAULT_LON = 7.4474
+DEFAULT_TZ = "Europe/Zurich"
+
+
+def guess_timezone(lat: float, lon: float) -> str:
+    """Return timezone name for the coordinates or ``DEFAULT_TZ``."""
+    if TimezoneFinder is None:
+        return DEFAULT_TZ
+    tz = TimezoneFinder().timezone_at(lat=lat, lng=lon)
+    return tz or DEFAULT_TZ
+
+
+def set_timezone(tz: str) -> None:
+    """Apply timezone using ``timedatectl``."""
+    subprocess.run(["sudo", "timedatectl", "set-timezone", tz], check=False)
+
+
+def set_time(dt_str: str) -> None:
+    """Set the system time using ``timedatectl``."""
+    subprocess.run(["sudo", "timedatectl", "set-time", dt_str], check=False)
+
+
+def configure(dt_str: str, lat: float | None = None, lon: float | None = None) -> str:
+    """Configure time and timezone and return the applied timezone."""
+    if lat is None or lon is None:
+        lat, lon = DEFAULT_LAT, DEFAULT_LON
+    tz = guess_timezone(lat, lon)
+    set_timezone(tz)
+    set_time(dt_str)
+    return tz
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Initial time configuration")
+    parser.add_argument("datetime", help="Current date/time 'YYYY-MM-DD HH:MM:SS'")
+    parser.add_argument("--lat", type=float, help="Latitude")
+    parser.add_argument("--lon", type=float, help="Longitude")
+    args = parser.parse_args()
+    tz = configure(args.datetime, args.lat, args.lon)
+    print(f"Timezone set to {tz}")
+
+
+if __name__ == "__main__":
+    main()

--- a/NightScanPi/README.md
+++ b/NightScanPi/README.md
@@ -19,6 +19,8 @@ Saisir la position GPS de l’installation
 
 (Facultatif) Activer l’envoi via module SIM si installé et si un abonnement a été souscrit
 
+Configurer la date et l'heure avec `time_config.py` (coordonnées GPS nécessaires pour le fuseau horaire)
+
 🧩 Composants
 Composant	Fonction
 Raspberry Pi Zero 2 W	Unité centrale
@@ -133,3 +135,11 @@ Ce répertoire contient les scripts Python exécutés sur le Raspberry Pi :
 - `wifi_config.py` écrit la configuration Wi-Fi reçue via l'application mobile.
 - `sync.py` envoie automatiquement les fichiers générés.
 - `utils/energy_manager.py` gère la plage horaire d'activité.
+- `time_config.py` règle l'heure et le fuseau en début d'installation.
+
+### Synchronisation horaire
+Pour définir l'heure et le fuseau, exécutez :
+```bash
+python time_config.py "2024-01-01 12:00:00" --lat 46.9 --lon 7.4
+```
+Si aucune coordonnée n'est fournie, celles de Berne sont utilisées.

--- a/TODO_NightScanPi.md
+++ b/TODO_NightScanPi.md
@@ -34,8 +34,8 @@ Cette liste pourra être complétée au fur et à mesure de l'avancement du proj
 - [x] Fournir un exemple de fichier de configuration et activer un journal des erreurs.
 
 ## 5. Synchronisation horaire
-- [ ] Écrire un script `time_config.py` pour saisir l'heure actuelle et la position GPS lors de la première configuration.
-- [ ] Si aucune position n'est fournie, utiliser par défaut les coordonnées de Berne (46.9480 N, 7.4474 E).
-- [ ] Déterminer le fuseau horaire à partir de la position avec `timezonefinder` et l'appliquer via `timedatectl`.
+- [x] Écrire un script `time_config.py` pour saisir l'heure actuelle et la position GPS lors de la première configuration.
+- [x] Si aucune position n'est fournie, utiliser par défaut les coordonnées de Berne (46.9480 N, 7.4474 E).
+- [x] Déterminer le fuseau horaire à partir de la position avec `timezonefinder` et l'appliquer via `timedatectl`.
 - [ ] Installer et configurer `chrony` pour maintenir l'heure synchronisée via Wi‑Fi ou module SIM.
-- [ ] Documenter la procédure dans `NightScanPi/README.md`.
+- [x] Documenter la procédure dans `NightScanPi/README.md`.

--- a/tests/test_time_config.py
+++ b/tests/test_time_config.py
@@ -1,0 +1,31 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from NightScanPi.Program import time_config
+
+
+def test_configure_defaults(monkeypatch):
+    tf = types.SimpleNamespace(timezone_at=lambda lat, lng: "Europe/Zurich")
+    monkeypatch.setattr(time_config, "TimezoneFinder", lambda: tf)
+    calls = []
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+
+    monkeypatch.setattr(time_config.subprocess, "run", fake_run)
+
+    tz = time_config.configure("2024-01-01 12:00:00")
+    assert tz == "Europe/Zurich"
+    assert calls == [
+        ["sudo", "timedatectl", "set-timezone", "Europe/Zurich"],
+        ["sudo", "timedatectl", "set-time", "2024-01-01 12:00:00"],
+    ]
+
+
+def test_guess_timezone_fallback(monkeypatch):
+    monkeypatch.setattr(time_config, "TimezoneFinder", None)
+    tz = time_config.guess_timezone(0, 0)
+    assert tz == time_config.DEFAULT_TZ


### PR DESCRIPTION
## Summary
- implement `time_config.py` for timezone configuration
- document usage in `NightScanPi/README.md`
- tick items in `TODO_NightScanPi.md`
- add unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68622d4149f083338d2e5e9cf5cf3ba9