### PR TITLE
Implement chrony setup

### DIFF
--- a/NightScanPi/README.md
+++ b/NightScanPi/README.md
@@ -143,3 +143,13 @@ Pour définir l'heure et le fuseau, exécutez :
 python time_config.py "2024-01-01 12:00:00" --lat 46.9 --lon 7.4
 ```
 Si aucune coordonnée n'est fournie, celles de Berne sont utilisées.
+
+Pour conserver une heure précise durant l'utilisation, installez et activez
+`chrony` qui synchronisera automatiquement l'horloge dès qu'une connexion
+(Wi‑Fi ou module SIM) est disponible :
+
+```bash
+sudo apt install -y chrony
+sudo systemctl enable --now chrony
+sudo timedatectl set-ntp true
+```

--- a/NightScanPi/setup_pi.sh
+++ b/NightScanPi/setup_pi.sh
@@ -21,7 +21,7 @@ if [ ! -e /boot/ssh ]; then
 fi
 
 # Install required system packages
-PACKAGES=(python3-pip ffmpeg sox libatlas-base-dev)
+PACKAGES=(python3-pip ffmpeg sox libatlas-base-dev chrony)
 MISSING=()
 for pkg in "${PACKAGES[@]}"; do
     dpkg -s "$pkg" >/dev/null 2>&1 || MISSING+=("$pkg")
@@ -30,6 +30,12 @@ done
 if [ ${#MISSING[@]} -gt 0 ]; then
     $SUDO apt update
     $SUDO apt install -y "${MISSING[@]}"
+fi
+
+# Enable and start chrony to keep the clock in sync
+if command -v systemctl >/dev/null 2>&1; then
+    $SUDO systemctl enable --now chrony >/dev/null 2>&1 || true
+    $SUDO timedatectl set-ntp true >/dev/null 2>&1 || true
 fi
 
 # Setup Python environment

--- a/TODO_NightScanPi.md
+++ b/TODO_NightScanPi.md
@@ -37,5 +37,5 @@ Cette liste pourra être complétée au fur et à mesure de l'avancement du proj
 - [x] Écrire un script `time_config.py` pour saisir l'heure actuelle et la position GPS lors de la première configuration.
 - [x] Si aucune position n'est fournie, utiliser par défaut les coordonnées de Berne (46.9480 N, 7.4474 E).
 - [x] Déterminer le fuseau horaire à partir de la position avec `timezonefinder` et l'appliquer via `timedatectl`.
-- [ ] Installer et configurer `chrony` pour maintenir l'heure synchronisée via Wi‑Fi ou module SIM.
+- [x] Installer et configurer `chrony` pour maintenir l'heure synchronisée via Wi‑Fi ou module SIM.
 - [x] Documenter la procédure dans `NightScanPi/README.md`.


### PR DESCRIPTION
## Summary
- install and enable chrony via `setup_pi.sh`
- document time synchronization in `NightScanPi/README.md`
- mark chrony task done in `TODO_NightScanPi.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686231649b788333bee2f9abc1b2c7aa