### PR TITLE
Implement wifi wakeup script

### DIFF
--- a/NightScanPi/Program/wifi_wakeup.py
+++ b/NightScanPi/Program/wifi_wakeup.py
@@ -1,0 +1,112 @@
+"""Wi-Fi wakeup via acoustic signal detection."""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import sounddevice as sd
+except Exception:  # pragma: no cover - missing dependency
+    sd = None  # type: ignore
+
+
+RATE = int(os.getenv("NIGHTSCAN_WAKE_RATE", "22050"))
+TARGET_FREQ = int(os.getenv("NIGHTSCAN_WAKE_FREQ", "2100"))
+THRESHOLD = float(os.getenv("NIGHTSCAN_WAKE_THRESHOLD", "10"))
+DURATION = float(os.getenv("NIGHTSCAN_WAKE_DURATION", "0.5"))
+STATUS_FILE = Path(os.getenv("NIGHTSCAN_WAKE_STATUS", "wifi_awake.status"))
+DOWN_AFTER = int(os.getenv("NIGHTSCAN_WAKE_TIME", "600"))  # seconds
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
+)
+
+
+def _read_status() -> float | None:
+    try:
+        return float(STATUS_FILE.read_text())
+    except Exception:
+        return None
+
+
+def _write_status(ts: float) -> None:
+    try:
+        STATUS_FILE.write_text(str(ts))
+    except Exception:
+        pass
+
+
+def _remove_status() -> None:
+    try:
+        STATUS_FILE.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def wifi_up() -> None:
+    subprocess.run(["sudo", "ifconfig", "wlan0", "up"], check=False)
+
+
+def wifi_down() -> None:
+    subprocess.run(["sudo", "ifconfig", "wlan0", "down"], check=False)
+
+
+def network_available(host: str = "8.8.8.8", port: int = 53, timeout: int = 3) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout):
+            return True
+    except OSError:
+        return False
+
+
+def detect_tone() -> bool:
+    """Return True if a TARGET_FREQ tone is detected."""
+    if sd is None:
+        return False
+    rec = sd.rec(int(DURATION * RATE), samplerate=RATE, channels=1, dtype="float32")
+    sd.wait()
+    data = rec[:, 0]
+    window = np.hanning(len(data))
+    spec = np.abs(np.fft.rfft(data * window))
+    freqs = np.fft.rfftfreq(len(data), d=1 / RATE)
+    peak_idx = int(np.argmax(spec))
+    peak_freq = freqs[peak_idx]
+    amp = spec[peak_idx]
+    logger.debug("Detected peak %.1f Hz amplitude %.2f", peak_freq, amp)
+    return abs(peak_freq - TARGET_FREQ) < 50 and amp >= THRESHOLD
+
+
+def main() -> None:
+    if sd is None:
+        raise RuntimeError("sounddevice not available")
+    logger.info("Listening for wake-up tone at %d Hz", TARGET_FREQ)
+    wake_time = _read_status()
+    while True:
+        if wake_time is None:
+            if detect_tone():
+                logger.info("Wake-up tone detected")
+                wifi_up()
+                wake_time = time.time()
+                _write_status(wake_time)
+        else:
+            if network_available():
+                wake_time = time.time()
+                _write_status(wake_time)
+            elif time.time() - wake_time > DOWN_AFTER:
+                logger.info("Deactivating Wi-Fi after timeout")
+                wifi_down()
+                wake_time = None
+                _remove_status()
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ pillow==11.2.1
 platformdirs==4.3.8
 pluggy==1.6.0
 PyAudio==0.2.14
+sounddevice==0.4.6
 pyserial==3.5
 pydub==0.25.1
 PyMySQL==1.1.1

--- a/tests/test_wifi_wakeup.py
+++ b/tests/test_wifi_wakeup.py
@@ -1,0 +1,43 @@
+import types
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from NightScanPi.Program import wifi_wakeup
+
+
+def test_detect_tone(monkeypatch):
+    samples = int(wifi_wakeup.DURATION * wifi_wakeup.RATE)
+    t = wifi_wakeup.np.arange(samples) / wifi_wakeup.RATE
+    tone = wifi_wakeup.np.sin(2 * wifi_wakeup.np.pi * wifi_wakeup.TARGET_FREQ * t)
+    dummy_sd = types.SimpleNamespace(
+        rec=lambda *a, **k: tone.astype("float32").reshape(-1, 1),
+        wait=lambda: None,
+    )
+    monkeypatch.setattr(wifi_wakeup, "sd", dummy_sd)
+    assert wifi_wakeup.detect_tone()
+
+
+def test_main_activates_wifi(monkeypatch):
+    events = []
+    monkeypatch.setattr(wifi_wakeup, "sd", types.SimpleNamespace())
+    monkeypatch.setattr(wifi_wakeup, "detect_tone", lambda: True)
+    monkeypatch.setattr(wifi_wakeup, "network_available", lambda: False)
+    monkeypatch.setattr(wifi_wakeup, "_read_status", lambda: None)
+    monkeypatch.setattr(wifi_wakeup, "_write_status", lambda ts: events.append("write"))
+    monkeypatch.setattr(wifi_wakeup, "wifi_up", lambda: events.append("up"))
+    monkeypatch.setattr(wifi_wakeup, "wifi_down", lambda: events.append("down"))
+
+    def fake_sleep(t):
+        raise SystemExit()
+
+    monkeypatch.setattr(wifi_wakeup.time, "sleep", fake_sleep)
+
+    with monkeypatch.context() as m:
+        m.setattr(wifi_wakeup, "sd", types.SimpleNamespace())
+        with pytest.raises(SystemExit):
+            wifi_wakeup.main()
+
+    assert "up" in events


### PR DESCRIPTION
## Summary
- add new script `wifi_wakeup.py` to enable Wi-Fi when a 2100Hz tone is detected
- include sounddevice dependency
- test tone detection and activation logic

## Testing
- `ruff check NightScanPi/Program/wifi_wakeup.py tests/test_wifi_wakeup.py --fix`
- `black NightScanPi/Program/wifi_wakeup.py tests/test_wifi_wakeup.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862dd4118dc8333845ca9f921871739