### PR TITLE
Implement Wi‑Fi wake benchmark and update Pi setup

### DIFF
--- a/NightScanPi/Program/benchmark_wifi_wakeup.py
+++ b/NightScanPi/Program/benchmark_wifi_wakeup.py
@@ -1,0 +1,30 @@
+"""Benchmark wifi_wakeup tone detection CPU usage."""
+from __future__ import annotations
+
+import time
+import os
+
+import NightScanPi.Program.wifi_wakeup as wifi_wakeup
+
+
+def benchmark(iterations: int = 100) -> float:
+    """Return average CPU usage percentage for tone detection."""
+    start_wall = time.perf_counter()
+    start_cpu = time.process_time()
+    for _ in range(iterations):
+        wifi_wakeup.detect_tone()
+    cpu_time = time.process_time() - start_cpu
+    wall_time = time.perf_counter() - start_wall
+    if wall_time == 0:
+        return 0.0
+    return 100.0 * cpu_time / wall_time
+
+
+def main() -> None:
+    iterations = int(os.getenv("NIGHTSCAN_BENCH_ITERS", "100"))
+    usage = benchmark(iterations)
+    print(f"Average CPU usage over {iterations} detections: {usage:.1f}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/NightScanPi/README.md
+++ b/NightScanPi/README.md
@@ -101,7 +101,7 @@ Copier
 Modifier
 sudo apt update
 sudo apt install python3-pip ffmpeg sox libatlas-base-dev
-pip3 install numpy opencv-python soundfile flask
+pip3 install numpy opencv-python soundfile sounddevice scipy flask
 🔌 Gestion énergétique
 TPL5110 coupe automatiquement le courant en dehors de la plage horaire utile
 

--- a/NightScanPi/setup_pi.sh
+++ b/NightScanPi/setup_pi.sh
@@ -42,7 +42,7 @@ fi
 python3 -m venv env
 source env/bin/activate
 pip install --upgrade pip
-pip install numpy opencv-python soundfile flask pyaudio
+pip install numpy opencv-python soundfile sounddevice scipy flask pyaudio
 
 # Install repository requirements if present
 if [ -f requirements.txt ]; then

--- a/docs/en/pi_setup.md
+++ b/docs/en/pi_setup.md
@@ -25,6 +25,7 @@ Create and activate a virtual environment and install the required modules:
 python3 -m venv env
 source env/bin/activate
 pip install numpy opencv-python soundfile flask pyaudio
+pip install sounddevice scipy
 ```
 
 Alternatively you can run the `NightScanPi/setup_pi.sh` script which performs the steps above automatically.

--- a/tests/test_benchmark_wifi_wakeup.py
+++ b/tests/test_benchmark_wifi_wakeup.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from NightScanPi.Program import benchmark_wifi_wakeup
+
+
+def test_benchmark(monkeypatch):
+    # Ensure detect_tone runs quickly
+    monkeypatch.setattr(benchmark_wifi_wakeup.wifi_wakeup, "detect_tone", lambda: None)
+    usage = benchmark_wifi_wakeup.benchmark(10)
+    assert 0 <= usage <= 100


### PR DESCRIPTION
## Summary
- install `sounddevice` and `scipy` when configuring NightScanPi
- document the extra Python packages in the setup guides
- add a small benchmark script for Wi-Fi wake tone detection
- test the benchmark script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868eb85f4748333a33aeebba908700f