### PR TITLE
Enhance iOS app docs and tests

### DIFF
--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -22,6 +22,17 @@ npx expo start
 ```
 After the Metro bundler starts, scan the QR code in your terminal with the Expo Go app to launch NightScan on your device.
 
+## Building a Release
+
+To generate a standalone iOS build you can rely on Expo's EAS tooling. Install EAS CLI and run:
+
+```bash
+npm install -g eas-cli
+eas build --platform ios
+```
+
+You will need an Apple developer account to sign the application. The resulting IPA can be deployed to TestFlight or the App Store.
+
 ### Wake tone asset
 
 The repository does not store the wake tone audio file directly. It will be generated automatically when you run `npm start` thanks to the `prestart` script in `package.json`.
@@ -49,4 +60,14 @@ functions in `services/api.js`. After logging in, the detection list requests
 ## Offline caching
 
 The detection list is stored in AsyncStorage so it remains available when the device is offline. Pull down on the list to refresh the cache when a network connection is available.
+
+## Running Tests
+
+Unit tests are written with Jest and React Native Testing Library. After installing dependencies, run:
+
+```bash
+npm test
+```
+
+All test suites should pass and verify the main screens' behaviour.
 

--- a/ios-app/__tests__/HomeScreen.test.js
+++ b/ios-app/__tests__/HomeScreen.test.js
@@ -2,6 +2,16 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 import HomeScreen from '../screens/HomeScreen';
 
+jest.mock('expo-av', () => ({
+  Audio: {
+    Sound: {
+      createAsync: jest.fn(() => Promise.resolve({
+        sound: { unloadAsync: jest.fn(), playAsync: jest.fn() }
+      })),
+    },
+  },
+}));
+
 it('shows welcome message', () => {
   const navigation = { navigate: jest.fn() };
   const { getByText } = render(<HomeScreen navigation={navigation} />);


### PR DESCRIPTION
## Summary
- mock `expo-av` in HomeScreen test so Jest can run
- document release build steps using EAS
- mention how to run Jest tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686928f75c608333913983640934d011